### PR TITLE
Add crafting and gathering items

### DIFF
--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -15,7 +15,7 @@ namespace Dalamud.FindAnything
         public SearchSetting ToSearchV3 { get; set; } =
             SearchSetting.Aetheryte | SearchSetting.Duty | SearchSetting.MainCommand | SearchSetting.GeneralAction |
             SearchSetting.Emote | SearchSetting.PluginSettings
-            | SearchSetting.Gearsets | SearchSetting.Reserved1 | SearchSetting.Reserved2 | SearchSetting.Reserved3 |
+            | SearchSetting.Gearsets | SearchSetting.CraftingRecipes | SearchSetting.GatheringItems | SearchSetting.Reserved3 |
             SearchSetting.Reserved4 | SearchSetting.Reserved5 | SearchSetting.Reserved6 | SearchSetting.Reserved7 |
             SearchSetting.Reserved8
             | SearchSetting.Reserved9 | SearchSetting.Reserved10 | SearchSetting.Reserved11 | SearchSetting.Reserved12 |
@@ -50,8 +50,8 @@ namespace Dalamud.FindAnything
             Emote = 1 << 4,
             PluginSettings = 1 << 5,
             Gearsets = 1 << 6,
-            Reserved1 = 1 << 7,
-            Reserved2 = 1 << 8,
+            CraftingRecipes = 1 << 7,
+            GatheringItems = 1 << 8,
             Reserved3 = 1 << 9,
             Reserved4 = 1 << 10,
             Reserved5 = 1 << 11,

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -702,6 +702,37 @@ namespace Dalamud.FindAnything
             }
         }
 
+        private class CraftingRecipeResult : ISearchResult {
+            public string CatName => "Crafting Recipe";
+            public string Name { get; set; }
+            public TextureWrap? Icon { get; set; }
+            public bool CloseFinder => true;
+            
+            public Recipe Recipe { get; set; }
+
+            public void Selected() {
+                var id = this.Recipe.ItemResult.Value?.RowId ?? 0;
+                if (id > 0) {
+                    GameStateCache.SearchForItemByCraftingMethod((ushort) (id % 500_000));
+                }
+            }
+        }
+
+        private class GatheringItemResult : ISearchResult {
+            public string CatName => "Gathering Item";
+            public string Name { get; set; }
+            public TextureWrap? Icon { get; set; }
+            public bool CloseFinder => true;
+            
+            public GatheringItem Item { get; set; }
+
+            public void Selected() {
+                if (this.Item.Item > 0) {
+                    GameStateCache.SearchForItemByGatheringMethod((ushort) (this.Item.Item % 500_000));
+                }
+            }
+        }
+
         private static ISearchResult[]? results;
 
         public static ICallGateSubscriber<uint, byte, bool> TeleportIpc { get; private set; }
@@ -878,6 +909,60 @@ namespace Dalamud.FindAnything
                                     Gearset = gearset,
                                 });
                             }
+                        }
+                    }
+
+                    if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.CraftingRecipes)) {
+                        foreach (var recipe in Data.GetExcelSheet<Recipe>()!) {
+                            var itemResult = recipe.ItemResult.Value;
+                            if (itemResult == null || itemResult.RowId == 0) {
+                                continue;
+                            }
+
+                            var name = itemResult.Name.RawString;
+
+                            if (name.ToLower().Contains(term)) {
+                                TexCache.EnsureExtraIcon(itemResult.Icon);
+                                TexCache.ExtraIcons.TryGetValue(itemResult.Icon, out var tex);
+
+                                cResults.Add(new CraftingRecipeResult
+                                {
+                                    Recipe = recipe,
+                                    Name = name,
+                                    Icon = tex,
+                                });
+                            }
+
+                            if (cResults.Count > MAX_TO_SEARCH)
+                                break;
+                        }
+                    }
+                    
+                    if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.GatheringItems)) {
+                        var items = Data.GetExcelSheet<Item>()!;
+                        
+                        foreach (var gather in Data.GetExcelSheet<GatheringItem>()!) {
+                            var item = items.GetRow((uint) gather.Item);
+                            if (item == null || item.RowId == 0) {
+                                continue;
+                            }
+
+                            var name = item.Name.RawString;
+
+                            if (name.ToLower().Contains(term)) {
+                                TexCache.EnsureExtraIcon(item.Icon);
+                                TexCache.ExtraIcons.TryGetValue(item.Icon, out var tex);
+
+                                cResults.Add(new GatheringItemResult()
+                                {
+                                    Item = gather,
+                                    Name = name,
+                                    Icon = tex,
+                                });
+                            }
+
+                            if (cResults.Count > MAX_TO_SEARCH)
+                                break;
                         }
                     }
 

--- a/Dalamud.FindAnything/GameStateCache.cs
+++ b/Dalamud.FindAnything/GameStateCache.cs
@@ -27,6 +27,14 @@ public unsafe class GameStateCache
 
     private readonly IsEmoteUnlockedDelegate? isEmoteUnlocked;
 
+    private delegate void SearchForItemByCraftingMethodDelegate(AgentInterface* agent, ushort itemId);
+
+    private readonly SearchForItemByCraftingMethodDelegate? searchForItemByCraftingMethod;
+
+    private delegate void SearchForItemByGatheringMethodDelegate(AgentInterface* agent, ushort itemId);
+
+    private readonly SearchForItemByGatheringMethodDelegate searchForItemByGatheringMethod;
+
     public struct Gearset
     {
         public int Slot { get; set; }
@@ -43,6 +51,16 @@ public unsafe class GameStateCache
         return this.isDutyUnlocked(contentId) > 0;
     }
 
+    internal void SearchForItemByCraftingMethod(ushort itemId) {
+        var agent = Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.RecipeNote);
+        this.searchForItemByCraftingMethod(agent, itemId);
+    }
+    
+    internal void SearchForItemByGatheringMethod(ushort itemId) {
+        var agent = Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.GatheringNote);
+        this.searchForItemByGatheringMethod(agent, itemId);
+    }
+
     private GameStateCache()
     {
         if (FindAnythingPlugin.TargetScanner.TryScanText("E9 ?? ?? ?? ?? E8 ?? ?? ?? ?? 0F B7 57 3C 48 8B C8 E8 ?? ?? ?? ?? 84 C0 75 D9", out var dutyUnlockedPtr)) {
@@ -53,6 +71,16 @@ public unsafe class GameStateCache
         if (FindAnythingPlugin.TargetScanner.TryScanText("E8 ?? ?? ?? ?? 84 C0 74 A4", out var emoteUnlockedPtr)) {
             PluginLog.Information($"emoteUnlockedPtr: {emoteUnlockedPtr:X}");
             this.isEmoteUnlocked = Marshal.GetDelegateForFunctionPointer<IsEmoteUnlockedDelegate>(emoteUnlockedPtr);
+        }
+
+        if (FindAnythingPlugin.TargetScanner.TryScanText("E8 ?? ?? ?? ?? EB 7A 48 83 F8 06", out var searchCraftingPtr)) {
+            PluginLog.Information($"searchCraftingPtr: {searchCraftingPtr:X}");
+            this.searchForItemByCraftingMethod = Marshal.GetDelegateForFunctionPointer<SearchForItemByCraftingMethodDelegate>(searchCraftingPtr);
+        }
+
+        if (FindAnythingPlugin.TargetScanner.TryScanText("E8 ?? ?? ?? ?? EB 38 48 83 F8 07", out var searchGatheringPtr)) {
+            PluginLog.Information($"searchGatheringPtr: {searchGatheringPtr:X}");
+            this.searchForItemByGatheringMethod = Marshal.GetDelegateForFunctionPointer<SearchForItemByGatheringMethodDelegate>(searchGatheringPtr);
         }
     }
 

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -65,6 +65,8 @@ public class SettingsWindow : Window
         ImGui.CheckboxFlags("Search in General Actions", ref this.flags, (uint) Configuration.SearchSetting.GeneralAction);
         ImGui.CheckboxFlags("Search in other plugins", ref this.flags, (uint) Configuration.SearchSetting.PluginSettings);
         ImGui.CheckboxFlags("Search in Gear Sets", ref this.flags, (uint) Configuration.SearchSetting.Gearsets);
+        ImGui.CheckboxFlags("Search in Crafting Recipes", ref this.flags, (uint) Configuration.SearchSetting.CraftingRecipes);
+        ImGui.CheckboxFlags("Search in Gathering Items", ref this.flags, (uint) Configuration.SearchSetting.GatheringItems);
 
         ImGuiHelpers.ScaledDummy(15);
         ImGui.Separator();


### PR DESCRIPTION
This does not check if you have the recipe unlocked. It opens the Crafting Log or Gathering Log and searches for the item name (same as the context menu items).

I suppose you could check if the player is within... 2 levels of the recipe group? There might be a sheet that handles when you can see recipes. I'm not sure there's a function for it, or I imagine it'd be hard to find if there is.