### PR TITLE
feat: add 'Closest Market Board' aetheryte option

### DIFF
--- a/Dalamud.FindAnything/AetheryteManager.cs
+++ b/Dalamud.FindAnything/AetheryteManager.cs
@@ -17,6 +17,15 @@ namespace Dalamud.FindAnything {
         private string? m_AppartmentName;
 
         private uint[] m_EstateIds = { 0 };
+        private readonly uint[] m_MarketBoardIds = {
+            2, // New Gridania
+            8, // Limsa Lominsa Lower Decks
+            9, // Ul'Dah - Steps of Nald
+            70, // Foundation
+            111, // Kugane
+            133, // Crystarium
+            182, // Old Sharlayan
+        };
 
         private AetheryteManager()
         {
@@ -32,6 +41,11 @@ namespace Dalamud.FindAnything {
             if (plot != 0 || ward != 0 || subId != 0)
                 return true;
             return m_EstateIds.Contains(id);
+        }
+
+        public bool IsMarketBoardAetheryte(uint id)
+		{
+            return m_MarketBoardIds.Contains(id);
         }
 
         public string GetAetheryteName(AetheryteEntry info) {

--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -119,6 +119,7 @@ namespace Dalamud.FindAnything
         public List<MacroEntry> MacroLinks { get; set; } = new();
 
         public bool DoAetheryteGilCost { get; set; } = false;
+        public bool DoMarketBoardShortcut { get; set; } = false;
         public EmoteMotionMode EmoteMode { get; set; } = EmoteMotionMode.Default;
         public bool ShowEmoteCommand { get; set; } = false;
 

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -54,7 +54,7 @@ namespace Dalamud.FindAnything
         [PluginService] public static ChatGui ChatGui { get; private set; }
         [PluginService] public static ToastGui ToastGui { get; private set; }
         [PluginService] public static Dalamud.Game.ClientState.Conditions.Condition Condition { get; private set; }
-        [PluginService] public static AetheryteList Aetheryes { get; private set; }
+        [PluginService] public static AetheryteList Aetherytes { get; private set; }
         [PluginService] public static SigScanner TargetScanner { get; private set; }
 
         public static TextureCache TexCache { get; private set; }
@@ -1077,7 +1077,8 @@ namespace Dalamud.FindAnything
                             case Configuration.SearchSetting.Aetheryte:
                                 if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.Aetheryte) && !isInDuty && !isInCombat)
                                 {
-                                    foreach (var aetheryte in Aetheryes)
+                                    var marketBoardResults = new List<AetheryteEntry>();
+                                    foreach (var aetheryte in Aetherytes)
                                     {
                                         var aetheryteName = AetheryteManager.GetAetheryteName(aetheryte);
                                         var terriName = SearchDatabase.GetString<TerritoryType>(aetheryte.TerritoryId);
@@ -1089,9 +1090,24 @@ namespace Dalamud.FindAnything
                                                 Icon = TexCache.AetheryteIcon,
                                                 TerriName = terriName.Display
                                             });
+                                            if (Configuration.DoMarketBoardShortcut && "Closest Market Board".ToLower().Contains(term) && AetheryteManager.IsMarketBoardAetheryte(aetheryte.AetheryteId))
+                                                marketBoardResults.Add(aetheryte);
 
                                         if (cResults.Count > MAX_TO_SEARCH)
                                             break;
+                                    }
+                                    if (marketBoardResults.Count > 0)
+                                    {
+                                        var closestMarketBoard = marketBoardResults.OrderBy(a1 => a1.GilCost).First();
+                                        var aetheryteName = AetheryteManager.GetAetheryteName(closestMarketBoard);
+                                        var terriName = SearchDatabase.GetString<TerritoryType>(closestMarketBoard.TerritoryId);
+                                        cResults.Add(new AetheryteSearchResult
+                                        {
+                                            Name = "Closest Market Board",
+                                            Data = closestMarketBoard,
+                                            Icon = TexCache.AetheryteIcon,
+                                            TerriName = terriName.Display
+                                        });
                                     }
                                 }
                                 break;

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -26,6 +26,7 @@ public class SettingsWindow : Window
     private bool preventPassthrough;
     private List<Configuration.MacroEntry> macros = new();
     private bool aetheryteGilCost;
+    private bool marketBoardShortcut;
     private Configuration.EmoteMotionMode emoteMotionMode;
     private bool showEmoteCommand;
     private bool wikiModeNoSpoilers;
@@ -58,6 +59,7 @@ public class SettingsWindow : Window
         this.preventPassthrough = FindAnythingPlugin.Configuration.PreventPassthrough;
         this.macros = FindAnythingPlugin.Configuration.MacroLinks.Select(x => new Configuration.MacroEntry(x)).ToList();
         this.aetheryteGilCost = FindAnythingPlugin.Configuration.DoAetheryteGilCost;
+        this.marketBoardShortcut = FindAnythingPlugin.Configuration.DoMarketBoardShortcut;
         this.emoteMotionMode = FindAnythingPlugin.Configuration.EmoteMode;
         this.showEmoteCommand = FindAnythingPlugin.Configuration.ShowEmoteCommand;
         this.wikiModeNoSpoilers = FindAnythingPlugin.Configuration.WikiModeNoSpoilers;
@@ -197,6 +199,7 @@ public class SettingsWindow : Window
         ImGui.TextColored(ImGuiColors.DalamudGrey, "Other stuff");
 
         ImGui.Checkbox("Show Gil cost in Aetheryte results", ref this.aetheryteGilCost);
+        ImGui.Checkbox("Show \"Market Board\" shortcut to teleport to the closest market board city", ref this.marketBoardShortcut);
 
         if (ImGui.BeginCombo("Emote Motion-Only?", this.emoteMotionMode.ToString()))
         {
@@ -252,6 +255,7 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.MacroLinks = this.macros;
 
             FindAnythingPlugin.Configuration.DoAetheryteGilCost = this.aetheryteGilCost;
+            FindAnythingPlugin.Configuration.DoMarketBoardShortcut = this.marketBoardShortcut;
             FindAnythingPlugin.Configuration.EmoteMode = this.emoteMotionMode;
             FindAnythingPlugin.Configuration.ShowEmoteCommand = this.showEmoteCommand;
             FindAnythingPlugin.Configuration.WikiModeNoSpoilers = this.wikiModeNoSpoilers;


### PR DESCRIPTION
Added a small thing that I find handy -- no clue if it's something that other people want as well, so I just thought to raise it and see.

This PR adds a new boolean option that enables quickly teleporting to the closest city with a market board:
![image](https://user-images.githubusercontent.com/4076797/152648117-6e69e261-16ef-4bca-9cfb-9720c202352f.png)

![image](https://user-images.githubusercontent.com/4076797/152648134-bddcb620-e4b0-491a-a1e9-2234b0637a74.png)

It's disabled by default, as many XIVQuickLauncher users probably have 2FA enabled and a free teleport which is most likely set to a major city already (and so the option will always list "Limsa - 0 gil" for example). Of course, they might have their free location set to an aetheryte that isn't a market board city, so this could still be handy for them.
