### PR TITLE
Teleporter IPC update - respect "Show chat message" configuration value

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -399,12 +399,13 @@ namespace Dalamud.FindAnything
                 try
                 {
                     var didTeleport = TeleportIpc.InvokeFunc(Data.AetheryteId, Data.SubIndex);
+                    var showTeleportChatMessage = ShowTeleportChatMessageIpc.InvokeFunc();
 
                     if (!didTeleport)
                     {
                         UserError("Cannot teleport in this situation.");
                     }
-                    else
+                    else if (showTeleportChatMessage)
                     {
                         ChatGui.Print($"Teleporting to {Name}...");
                     }
@@ -1202,6 +1203,7 @@ namespace Dalamud.FindAnything
         private static ISearchResult[]? results;
 
         public static ICallGateSubscriber<uint, byte, bool> TeleportIpc { get; private set; }
+        public static ICallGateSubscriber<bool> ShowTeleportChatMessageIpc {get; private set; }
 
         public FindAnythingPlugin()
         {
@@ -1231,6 +1233,7 @@ namespace Dalamud.FindAnything
             };
 
             TeleportIpc = PluginInterface.GetIpcSubscriber<uint, byte, bool>("Teleport");
+            ShowTeleportChatMessageIpc = PluginInterface.GetIpcSubscriber<bool>("Teleport.ChatMessage");
 
             TexCache = TextureCache.Load(null, Data);
             SearchDatabase = SearchDatabase.Load();


### PR DESCRIPTION
If a user teleports using Wotsit they currently receive a "Teleporting to..." message. Some users do not want to see these messages - but there is currently no way to disable receiving it from Wotsit because there is no configuration setting to disable it. Rather than add a configuration setting for Wotsit it made more sense to use the user's settings from Teleporter.

Pohky updated the Teleporter IPC to expose the configuration value for "Show Chat Messages" and so this PR is updating Wotsit to respect the setting.