### PR TITLE
fix: change keyboard focus properly

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -2195,7 +2195,7 @@ namespace Dalamud.FindAnything
             ImGui.PopItemWidth();
 
             if (ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows) && !ImGui.IsAnyItemActive() && !ImGui.IsMouseClicked(ImGuiMouseButton.Left))
-                ImGui.SetKeyboardFocusHere(0);
+                ImGui.SetKeyboardFocusHere(-1);
 
             ImGui.SameLine();
 


### PR DESCRIPTION
This fixes behavior that will break when ImGui 1.88 goes live for Dalamud users. It fixes the behavior in ImGui 1.88 and does nothing to the behavior of 1.83.