### PR TITLE
feat: add 'Closest Striking Dummy' aetheryte option

### DIFF
--- a/Dalamud.FindAnything/AetheryteManager.cs
+++ b/Dalamud.FindAnything/AetheryteManager.cs
@@ -23,6 +23,23 @@ namespace Dalamud.FindAnything {
             133, // Crystarium
             182, // Old Sharlayan
         };
+        private readonly uint[] m_StrikingDummyIds = {
+            3,
+            17,
+            23,
+            52,
+            71,
+            76,
+            98,
+            102,
+            107,
+            137,
+            140,
+            147,
+            166,
+            169,
+            181
+        };
 
         private AetheryteManager()
         {
@@ -43,6 +60,11 @@ namespace Dalamud.FindAnything {
         public bool IsMarketBoardAetheryte(uint id)
         {
             return m_MarketBoardIds.Contains(id);
+        }
+        
+        public bool IsStrikingDummyAetheryte(uint id)
+        {
+            return m_StrikingDummyIds.Contains(id);
         }
 
         public string GetAetheryteName(AetheryteEntry info) {

--- a/Dalamud.FindAnything/AetheryteManager.cs
+++ b/Dalamud.FindAnything/AetheryteManager.cs
@@ -24,21 +24,21 @@ namespace Dalamud.FindAnything {
             182, // Old Sharlayan
         };
         private readonly uint[] m_StrikingDummyIds = {
-            3,
-            17,
-            23,
-            52,
-            71,
-            76,
-            98,
-            102,
-            107,
-            137,
-            140,
-            147,
-            166,
-            169,
-            181
+            3, // New Gridania
+            17, // Horizon
+            23, // Camp Dragonhead
+            52, // Summerford Farms
+            71, // Falcon's Nest
+            76, // Tailfeather
+            98, // Castrum Oriens
+            102, // Porta Praetoria
+            107, // Namai
+            137, // Stilltide
+            140, // Mord Souq
+            147, // The Ondo Cups
+            166, // The Archeion
+            169, // Yedlihmad
+            181 // Base Omicron
         };
 
         private AetheryteManager()

--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -120,6 +120,7 @@ namespace Dalamud.FindAnything
 
         public bool DoAetheryteGilCost { get; set; } = false;
         public bool DoMarketBoardShortcut { get; set; } = false;
+        public bool DoStrikingDummyShortcut { get; set; } = false;
         public EmoteMotionMode EmoteMode { get; set; } = EmoteMotionMode.Default;
         public bool ShowEmoteCommand { get; set; } = false;
 

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1480,7 +1480,7 @@ namespace Dalamud.FindAnything
                                         if (Configuration.DoMarketBoardShortcut && "Closest Market Board".ToLower().Contains(term) && AetheryteManager.IsMarketBoardAetheryte(aetheryte.AetheryteId))
                                             marketBoardResults.Add(aetheryte);
 
-                                        if ("Closest Striking Dummy".ToLower().Contains(term) && AetheryteManager.IsStrikingDummyAetheryte(aetheryte.AetheryteId))
+                                        if (Configuration.DoStrikingDummyShortcut && "Closest Striking Dummy".ToLower().Contains(term) && AetheryteManager.IsStrikingDummyAetheryte(aetheryte.AetheryteId))
                                             strikingDummyResults.Add(aetheryte);
 
                                         if (cResults.Count > MAX_TO_SEARCH)

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1463,6 +1463,7 @@ namespace Dalamud.FindAnything
                                 if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.Aetheryte) && !isInDuty && !isInCombat)
                                 {
                                     var marketBoardResults = new List<AetheryteEntry>();
+                                    var strikingDummyResults = new List<AetheryteEntry>();
                                     foreach (var aetheryte in Aetherytes)
                                     {
                                         var aetheryteName = AetheryteManager.GetAetheryteName(aetheryte);
@@ -1479,6 +1480,9 @@ namespace Dalamud.FindAnything
                                         if (Configuration.DoMarketBoardShortcut && "Closest Market Board".ToLower().Contains(term) && AetheryteManager.IsMarketBoardAetheryte(aetheryte.AetheryteId))
                                             marketBoardResults.Add(aetheryte);
 
+                                        if ("Closest Striking Dummy".ToLower().Contains(term) && AetheryteManager.IsStrikingDummyAetheryte(aetheryte.AetheryteId))
+                                            strikingDummyResults.Add(aetheryte);
+
                                         if (cResults.Count > MAX_TO_SEARCH)
                                             break;
                                     }
@@ -1490,6 +1494,18 @@ namespace Dalamud.FindAnything
                                         {
                                             Name = "Closest Market Board",
                                             Data = closestMarketBoard,
+                                            Icon = TexCache.AetheryteIcon,
+                                            TerriName = terriName.Display
+                                        });
+                                    }
+                                    if (strikingDummyResults.Count > 0)
+                                    {
+                                        var closestStrikingDummy = strikingDummyResults.OrderBy(a1 => a1.GilCost).First();
+                                        var terriName = SearchDatabase.GetString<TerritoryType>(closestStrikingDummy.TerritoryId);
+                                        cResults.Add(new AetheryteSearchResult
+                                        {
+                                            Name = "Closest Striking Dummy",
+                                            Data = closestStrikingDummy,
                                             Icon = TexCache.AetheryteIcon,
                                             TerriName = terriName.Display
                                         });

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -27,6 +27,7 @@ public class SettingsWindow : Window
     private List<Configuration.MacroEntry> macros = new();
     private bool aetheryteGilCost;
     private bool marketBoardShortcut;
+    private bool strikingDummyShortcut;
     private Configuration.EmoteMotionMode emoteMotionMode;
     private bool showEmoteCommand;
     private bool wikiModeNoSpoilers;
@@ -61,6 +62,7 @@ public class SettingsWindow : Window
         this.macros = FindAnythingPlugin.Configuration.MacroLinks.Select(x => new Configuration.MacroEntry(x)).ToList();
         this.aetheryteGilCost = FindAnythingPlugin.Configuration.DoAetheryteGilCost;
         this.marketBoardShortcut = FindAnythingPlugin.Configuration.DoMarketBoardShortcut;
+        this.strikingDummyShortcut = FindAnythingPlugin.Configuration.DoStrikingDummyShortcut;
         this.emoteMotionMode = FindAnythingPlugin.Configuration.EmoteMode;
         this.showEmoteCommand = FindAnythingPlugin.Configuration.ShowEmoteCommand;
         this.wikiModeNoSpoilers = FindAnythingPlugin.Configuration.WikiModeNoSpoilers;
@@ -203,6 +205,7 @@ public class SettingsWindow : Window
         ImGui.Checkbox("Enable Search History", ref this.historyEnabled);
         ImGui.Checkbox("Show Gil cost in Aetheryte results", ref this.aetheryteGilCost);
         ImGui.Checkbox("Show \"Market Board\" shortcut to teleport to the closest market board city", ref this.marketBoardShortcut);
+        ImGui.Checkbox("Show \"Striking Dummy\" shortcut to teleport to the closest striking dummy location", ref this.strikingDummyShortcut);
 
         if (ImGui.BeginCombo("Emote Motion-Only?", this.emoteMotionMode.ToString()))
         {
@@ -259,6 +262,7 @@ public class SettingsWindow : Window
 
             FindAnythingPlugin.Configuration.DoAetheryteGilCost = this.aetheryteGilCost;
             FindAnythingPlugin.Configuration.DoMarketBoardShortcut = this.marketBoardShortcut;
+            FindAnythingPlugin.Configuration.DoStrikingDummyShortcut = this.strikingDummyShortcut;
             FindAnythingPlugin.Configuration.EmoteMode = this.emoteMotionMode;
             FindAnythingPlugin.Configuration.ShowEmoteCommand = this.showEmoteCommand;
             FindAnythingPlugin.Configuration.WikiModeNoSpoilers = this.wikiModeNoSpoilers;


### PR DESCRIPTION
I find the 'Closest Market Board' shortcut really useful, this is a very similar feature that adds a 'Closest Striking Dummy' shortcut since it can be quite hard to remember (personally) where the nearest one is; as they're not directly in major cities, but usually a settlement nearby.

It works **exactly** the same as the existing 'Closest Market Board', just with a new set of ID's of aetherytes near striking dummies.

![image](https://user-images.githubusercontent.com/47895641/182850801-df219108-8439-45f3-a1e5-87013e3f30c8.png)
![image](https://user-images.githubusercontent.com/47895641/182850869-25b4f3c4-1b0a-4644-ad59-08f796eace2d.png)
