### PR TITLE
Fix for unable to open wotsit in island sanctuary

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1349,6 +1349,9 @@ namespace Dalamud.FindAnything
 
         private static bool CheckInDuty()
         {
+            // Island Sanctuary
+            if (ClientState.TerritoryType == 1055) return false;
+
             return Condition[ConditionFlag.BoundByDuty] || Condition[ConditionFlag.BoundByDuty56] ||
                    Condition[ConditionFlag.BoundByDuty95];
         }


### PR DESCRIPTION
Island Sanctuary is TerritoryID 1055, not sure if you would prefer a different method of filtering that out or not, this is what I did for my plugins.