### PR TITLE
Update XivCommon to fix DutyFinder not opening on duty search

### DIFF
--- a/Dalamud.FindAnything/Dalamud.FindAnything.csproj
+++ b/Dalamud.FindAnything/Dalamud.FindAnything.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>goat</Authors>
-    <Version>1.0.1.11</Version>
+    <Version>1.0.1.12</Version>
     <Description>Finder of anything</Description>
     <Copyright>(c) 2021 goaaats</Copyright>
     <PackageProjectUrl>https://github.com/goaaats/Dalamud.FindAnything</PackageProjectUrl>
@@ -90,7 +90,7 @@
     <PackageReference Include="DalamudPackager" Version="2.1.8" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="NCalcSync" Version="2.0.0" />
-    <PackageReference Include="XivCommon" Version="4.0.0-alpha.2" />
+    <PackageReference Include="XivCommon" Version="6.0.2" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Dalamud.FindAnything/packages.lock.json
+++ b/Dalamud.FindAnything/packages.lock.json
@@ -29,9 +29,9 @@
       },
       "XivCommon": {
         "type": "Direct",
-        "requested": "[4.0.0-alpha.2, )",
-        "resolved": "4.0.0-alpha.2",
-        "contentHash": "ugdPMg3LKEWDY3DvdcfctjDW8QTaRnXfKJ9gFlY8036LVQ6guOG3grG65EIkIKIhbyg3b2E2ZWOhgeLYEcS00w=="
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "C/GnQ61iO0yEpf8LPixU3tCThar1MWUiBkO8gdZHNtVskg8AvFeuIxk7Zmkf2yeAJ0drR/KOTdSS7GpbsgmoaQ=="
       },
       "Antlr3.Runtime": {
         "type": "Transitive",


### PR DESCRIPTION
Updated XivCommon to v6.0.2 (current release)
Increased plugin version to 1.0.1.12

Fixes #43 
