### PR TITLE
Remove Final Sig from GameStateCache + Bugfix

### DIFF
--- a/Dalamud.FindAnything/GameStateCache.cs
+++ b/Dalamud.FindAnything/GameStateCache.cs
@@ -1,23 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Dalamud.Logging;
 using Dalamud.Memory;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 using Lumina.Excel.GeneratedSheets;
-using Framework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework;
 
 namespace Dalamud.FindAnything;
 
 public unsafe class GameStateCache
 {
-    private delegate void SearchForItemByGatheringMethodDelegate(AgentInterface* agent, ushort itemId);
-    private readonly SearchForItemByGatheringMethodDelegate searchForItemByGatheringMethod;
-
     public struct Gearset
     {
         public int Slot { get; set; }
@@ -35,17 +29,12 @@ public unsafe class GameStateCache
 
     internal void SearchForItemByCraftingMethod(ushort itemId) => AgentRecipeNote.Instance()->OpenRecipeByItemId(itemId);
 
-    internal void SearchForItemByGatheringMethod(ushort itemId) {
-        var agent = Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.GatheringNote);
-        this.searchForItemByGatheringMethod(agent, itemId);
-    }
+    internal void SearchForItemByGatheringMethod(ushort itemId) => AgentGatheringNote.Instance()->OpenGatherableByItemId(itemId);
 
     private GameStateCache()
     {
-        if (FindAnythingPlugin.TargetScanner.TryScanText("E8 ?? ?? ?? ?? EB 63 48 83 F8 ??", out var searchGatheringPtr)) {
-            PluginLog.Verbose($"searchGatheringPtr: {searchGatheringPtr:X}");
-            this.searchForItemByGatheringMethod = Marshal.GetDelegateForFunctionPointer<SearchForItemByGatheringMethodDelegate>(searchGatheringPtr);
-        }
+        // Nothing to do here =D
+        // MidoriKami removed all the sigs, sooooo yeah, happy fun times.
     }
 
     public void Refresh()

--- a/Dalamud.FindAnything/GameStateCache.cs
+++ b/Dalamud.FindAnything/GameStateCache.cs
@@ -44,7 +44,7 @@ public unsafe class GameStateCache
         var emotes = new List<uint>();
         foreach (var emote in FindAnythingPlugin.Data.GetExcelSheet<Emote>()!.Where(x => x.Order != 0))
         {
-            if (emote.UnlockLink == 0 || UIState.Instance()->IsUnlockLinkUnlocked(emote.UnlockLink))
+            if (emote.UnlockLink == 0 || UIState.Instance()->IsUnlockLinkUnlockedOrQuestCompleted(emote.UnlockLink))
             {
                 emotes.Add(emote.RowId);
             }
@@ -56,7 +56,7 @@ public unsafe class GameStateCache
         UnlockedMinionKeys = FindAnythingPlugin.Data.GetExcelSheet<Companion>()!.Where(x => IsMinionUnlocked(x.RowId)).Select(x => x.RowId).ToList();
         
         var gsModule = RaptureGearsetModule.Instance();
-        var cj = FindAnythingPlugin.Data.GetExcelSheet<ClassJob>()!;
+        
         var gearsets = new List<Gearset>();
         for (var i = 0; i < 100; i++)
         {


### PR DESCRIPTION
Replaces `SearchForItemByGatheringMethod` with ClientStructs `GatheringNote.Instance.OpenGatherableByItemId()`

This removes the last volatile sig from wotsit =D
The only sig left in the plugin is for SendChat, which has been stable for a long time.

Also fixes a bug where wotsit will not return emotes that were unlocked from quests.