### PR TITLE
Move stateful search logic to new SearchState class and add kana normalization

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1251,7 +1251,7 @@ namespace Dalamud.FindAnything
             ShowTeleportChatMessageIpc = PluginInterface.GetIpcSubscriber<bool>("Teleport.ChatMessage");
 
             TexCache = TextureCache.Load(null, Data);
-            SearchDatabase = SearchDatabase.Load();
+            SearchDatabase = SearchDatabase.Load(ClientState.ClientLanguage);
             AetheryteManager = AetheryteManager.Load();
 
             windowSystem = new WindowSystem("wotsit");
@@ -1396,6 +1396,7 @@ namespace Dalamud.FindAnything
 #endif
 
             var matcher = new FuzzyMatcher(criteria.MatchString, criteria.MatchMode);
+            var normalizeKana = criteria.ContainsKana;
             
             var isInDuty = CheckInDuty();
             var isInEvent = CheckInEvent();
@@ -1496,7 +1497,7 @@ namespace Dalamud.FindAnything
                                         var aetheryteName = AetheryteManager.GetAetheryteName(aetheryte);
                                         var terriName = SearchDatabase.GetString<TerritoryType>(aetheryte.TerritoryId);
                                         var score = matcher.MatchesAny(
-                                            aetheryteName.ToLower().Replace("'", string.Empty),
+                                            aetheryteName.Downcase(normalizeKana).Replace("'", string.Empty),
                                             terriName.Searchable
                                         );
                                         if (score > 0)
@@ -1509,11 +1510,11 @@ namespace Dalamud.FindAnything
                                                 TerriName = terriName.Display
                                             });
 
-                                        marketScore = matcher.Matches("Closest Market Board".ToLower());
+                                        marketScore = matcher.Matches("Closest Market Board".ToLowerInvariant());
                                         if (Configuration.DoMarketBoardShortcut && marketScore > 0 && AetheryteManager.IsMarketBoardAetheryte(aetheryte.AetheryteId))
                                             marketBoardResults.Add(aetheryte);
 
-                                        dummyScore = matcher.Matches("Closest Striking Dummy".ToLower());
+                                        dummyScore = matcher.Matches("Closest Striking Dummy".ToLowerInvariant());
                                         if (Configuration.DoStrikingDummyShortcut && dummyScore > 0 && AetheryteManager.IsStrikingDummyAetheryte(aetheryte.AetheryteId))
                                             strikingDummyResults.Add(aetheryte);
 
@@ -1648,7 +1649,7 @@ namespace Dalamud.FindAnything
 
                                     foreach (var plugin in DalamudReflector.OtherPlugins)
                                     {
-                                        var score = matcher.Matches(plugin.Name.ToLower());
+                                        var score = matcher.Matches(plugin.Name.Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new PluginSettingsSearchResult
@@ -1693,9 +1694,9 @@ namespace Dalamud.FindAnything
                                         var cjRow = cj.GetRow(gearset.ClassJob)!;
 
                                         var score = matcher.MatchesAny(
-                                            gearset.Name.ToLower(),
-                                            cjRow.Name.RawString.ToLower(),
-                                            cjRow.Abbreviation.RawString.ToLower(),
+                                            gearset.Name.Downcase(normalizeKana),
+                                            cjRow.Name.RawString.Downcase(normalizeKana),
+                                            cjRow.Abbreviation.RawString.ToLowerInvariant(),
                                             ClassJobRolesMap[gearset.ClassJob]
                                         );
                                         if (score > 0)
@@ -1789,7 +1790,7 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedMountKeys.Contains(mount.RowId))
                                             continue;
 
-                                        var score = matcher.Matches(mount.Singular.RawString.ToLower());
+                                        var score = matcher.Matches(mount.Singular.RawString.Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new MountResult
@@ -1812,7 +1813,7 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedMinionKeys.Contains(minion.RowId))
                                             continue;
 
-                                        var score = matcher.Matches(minion.Singular.RawString.ToLower()); 
+                                        var score = matcher.Matches(minion.Singular.RawString.Downcase(normalizeKana)); 
                                         if (score > 0)
                                         {
                                             cResults.Add(new MinionResult
@@ -1827,7 +1828,7 @@ namespace Dalamud.FindAnything
                             case Configuration.SearchSetting.MacroLinks:
                                 foreach (var macroLink in Configuration.MacroLinks)
                                 {
-                                    var score = matcher.Matches(macroLink.SearchName.ToLower());
+                                    var score = matcher.Matches(macroLink.SearchName.Downcase(normalizeKana));
                                     if (score > 0)
                                     {
                                         cResults.Add(new MacroLinkSearchResult
@@ -1841,7 +1842,7 @@ namespace Dalamud.FindAnything
                             case Configuration.SearchSetting.Internal:
                                 foreach (var kind in Enum.GetValues<InternalSearchResult.InternalSearchResultKind>())
                                 {
-                                    var score = matcher.Matches(InternalSearchResult.GetNameForKind(kind).ToLower());
+                                    var score = matcher.Matches(InternalSearchResult.GetNameForKind(kind).ToLowerInvariant());
                                     if (score > 0)
                                     {
                                         cResults.Add(new InternalSearchResult
@@ -2064,7 +2065,7 @@ namespace Dalamud.FindAnything
                             if (kind == WikiSiteChoicerResult.SiteChoice.TeamCraft && wikiResult.DataCat == WikiSearchResult.DataCategory.Item)
                                 continue;
 
-                            var score = matcher.Matches(kind.ToString().ToLower());
+                            var score = matcher.Matches(kind.ToString().ToLowerInvariant());
                             if (score > 0)
                             {
                                 cResults.Add(new WikiSiteChoicerResult

--- a/Dalamud.FindAnything/FuzzyMatcher.cs
+++ b/Dalamud.FindAnything/FuzzyMatcher.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using Dalamud.Logging;
 
 namespace Dalamud.FindAnything;
 
@@ -45,7 +44,7 @@ public readonly ref struct FuzzyMatcher
 
         for (var i = 0; i < span.Length; i++)
         {
-            if (span[i] != ' ')
+            if (span[i] is not ' ' and not '\u3000')
             {
                 if (wordStart < 0)
                 {

--- a/Dalamud.FindAnything/IpcSystem.cs
+++ b/Dalamud.FindAnything/IpcSystem.cs
@@ -104,7 +104,7 @@ public class IpcSystem : IDisposable
             Display = searchDisplayName,
             Guid = guid,
             IconId = iconId,
-            Search = searchValue.ToLower()
+            Search = searchValue.Downcase(normalizeKana: true)
         });
         
         PluginLog.Verbose($"[IPC] Registered: {pluginInternalName} - {searchDisplayName} - {guid}");

--- a/Dalamud.FindAnything/SearchState.cs
+++ b/Dalamud.FindAnything/SearchState.cs
@@ -9,6 +9,7 @@ internal class SearchState
     private string CleanString { get; set; } = string.Empty;
     private string SemanticString { get; set; } = string.Empty;
     private string MatchString { get; set; } = string.Empty;
+    private bool ContainsKana { get; set; } = false;
 
     private readonly Configuration config;
 
@@ -26,6 +27,7 @@ internal class SearchState
         CleanString = string.Empty;
         SemanticString = string.Empty;
         MatchString = string.Empty;
+        ContainsKana = false;
     }
 
     public void SetBaseSearchModeAndTerm(SearchMode searchMode, string term)
@@ -58,6 +60,7 @@ internal class SearchState
             CleanString = string.Empty;
             SemanticString = string.Empty;
             MatchString = string.Empty;
+            ContainsKana = false;
             return;
         }
 
@@ -93,6 +96,17 @@ internal class SearchState
         SemanticString = term;
 
         term = term.ToLower().Replace("'", string.Empty);
+        if (term.ContainsKana())
+        {
+            term = term.Downcase(normalizeKana: true).Replace("'", string.Empty);
+            ContainsKana = true;
+        }
+        else
+        {
+            term = term.ToLowerInvariant().Replace("'", string.Empty);
+            ContainsKana = false;
+        }
+        
         MatchString = term;
 
         MatchMode = matchMode;
@@ -100,7 +114,7 @@ internal class SearchState
 
     public SearchCriteria CreateCriteria()
     {
-        return new SearchCriteria(ActualSearchMode, MatchMode, CleanString, SemanticString, MatchString);
+        return new SearchCriteria(ActualSearchMode, MatchMode, CleanString, SemanticString, MatchString, ContainsKana);
     }
 }
 
@@ -119,15 +133,17 @@ public class SearchCriteria
     public string CleanString { get; }
     public string SemanticString { get; }
     public string MatchString { get; }
+    public bool ContainsKana { get; }
 
     public SearchCriteria(SearchMode searchMode, MatchMode matchMode, string cleanString, string semanticString,
-        string matchString)
+        string matchString, bool containsKana)
     {
         SearchMode = searchMode;
         MatchMode = matchMode;
         CleanString = cleanString;
         SemanticString = semanticString;
         MatchString = matchString;
+        ContainsKana = containsKana;
     }
 
     public bool HasMatchString()

--- a/Dalamud.FindAnything/SearchState.cs
+++ b/Dalamud.FindAnything/SearchState.cs
@@ -1,0 +1,137 @@
+﻿namespace Dalamud.FindAnything;
+
+internal class SearchState
+{
+    private SearchMode BaseSearchMode { get; set; } = SearchMode.Top;
+    public SearchMode ActualSearchMode { get; private set; } = SearchMode.Top;
+    private MatchMode MatchMode { get; set; } = MatchMode.Simple;
+    public string RawString { get; private set; } = string.Empty;
+    private string CleanString { get; set; } = string.Empty;
+    private string SemanticString { get; set; } = string.Empty;
+    private string MatchString { get; set; } = string.Empty;
+
+    private readonly Configuration config;
+
+    public SearchState(Configuration configuration)
+    {
+        config = configuration;
+    }
+
+    public void Reset()
+    {
+        BaseSearchMode = SearchMode.Top;
+        ActualSearchMode = SearchMode.Top;
+        MatchMode = config.MatchMode;
+        RawString = string.Empty;
+        CleanString = string.Empty;
+        SemanticString = string.Empty;
+        MatchString = string.Empty;
+    }
+
+    public void SetBaseSearchModeAndTerm(SearchMode searchMode, string term)
+    {
+        if (searchMode != BaseSearchMode)
+        {
+            BaseSearchMode = searchMode;
+            SetTerm(term);
+        }
+    }
+
+    public void SetBaseSearchMode(SearchMode searchMode)
+    {
+        if (searchMode != BaseSearchMode)
+        {
+            BaseSearchMode = searchMode;
+            SetTerm(RawString);
+        }
+    }
+
+    public void SetTerm(string term)
+    {
+        ActualSearchMode = BaseSearchMode;
+
+        if (term.Length == 0)
+        {
+            // Skip more complex initialization if we know the term is empty
+            MatchMode = config.MatchMode;
+            RawString = string.Empty;
+            CleanString = string.Empty;
+            SemanticString = string.Empty;
+            MatchString = string.Empty;
+            return;
+        }
+
+        RawString = term;
+
+        term = term.Trim();
+        CleanString = term;
+
+        // Only recognize the wiki sigil when we're in top mode.
+        if (BaseSearchMode == SearchMode.Top && term.StartsWith(FindAnythingPlugin.ModeSigilWiki))
+        {
+            term = term[1..];
+            ActualSearchMode = SearchMode.Wiki;
+        }
+
+        var matchMode = config.MatchMode;
+        if (!string.IsNullOrWhiteSpace(config.MatchSigilFuzzyParts) && term.StartsWith(config.MatchSigilFuzzyParts))
+        {
+            matchMode = MatchMode.FuzzyParts;
+            term = term[1..];
+        }
+        else if (!string.IsNullOrWhiteSpace(config.MatchSigilFuzzy) && term.StartsWith(config.MatchSigilFuzzy))
+        {
+            matchMode = MatchMode.Fuzzy;
+            term = term[1..];
+        }
+        else if (!string.IsNullOrWhiteSpace(config.MatchSigilSimple) && term.StartsWith(config.MatchSigilSimple))
+        {
+            matchMode = MatchMode.Simple;
+            term = term[1..];
+        }
+
+        SemanticString = term;
+
+        term = term.ToLower().Replace("'", string.Empty);
+        MatchString = term;
+
+        MatchMode = matchMode;
+    }
+
+    public SearchCriteria CreateCriteria()
+    {
+        return new SearchCriteria(ActualSearchMode, MatchMode, CleanString, SemanticString, MatchString);
+    }
+}
+
+public enum SearchMode
+{
+    Top,
+    Wiki,
+    WikiSiteChoicer,
+    EmoteModeChoicer
+}
+
+public class SearchCriteria
+{
+    public SearchMode SearchMode { get; }
+    public MatchMode MatchMode { get; }
+    public string CleanString { get; }
+    public string SemanticString { get; }
+    public string MatchString { get; }
+
+    public SearchCriteria(SearchMode searchMode, MatchMode matchMode, string cleanString, string semanticString,
+        string matchString)
+    {
+        SearchMode = searchMode;
+        MatchMode = matchMode;
+        CleanString = cleanString;
+        SemanticString = semanticString;
+        MatchString = matchString;
+    }
+
+    public bool HasMatchString()
+    {
+        return MatchString.Length != 0;
+    }
+}

--- a/Dalamud.FindAnything/StringExtensions.cs
+++ b/Dalamud.FindAnything/StringExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace Dalamud.FindAnything;
+
+public static class StringExtensions
+{
+    public static string Downcase(this string source, bool normalizeKana = false)
+    {
+        if (normalizeKana)
+        {
+            var span = source.AsSpan();
+            for (var t = 0; t < span.Length; t++)
+            {
+                if (span[t] is >= '\u3041' and <= '\u3096') // hiragana range
+                {
+                    var buffer = new char[span.Length];
+                    for (var i = 0; i < span.Length; i++)
+                    {
+                        var c = span[i];
+                        if (c is >= '\u3041' and <= '\u3096')
+                        {
+                            buffer[i] = (char)(c + 0x60); // convert to katakana
+                        }
+                        else
+                        {
+                            buffer[i] = char.ToLowerInvariant(c);
+                        }
+                    }
+
+                    return new ReadOnlySpan<char>(buffer).ToString();
+                }
+            }
+        }
+
+        return source.ToLowerInvariant();
+    }
+
+    public static bool ContainsKana(this string source)
+    {
+        var span = source.AsSpan();
+        for (var t = 0; t < span.Length; t++)
+        {
+            if (span[t] is >= '\u3041' and <= '\u3096' or >= '\u30a1' and <= '\u30f6')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This PR is currently in two parts/two commits just because that's how I developed it. It may be possible to do the second without the first but I'd like to present it this way at first.

It's probably hard to review this PR with both changes together, so I recommend reviewing each commit separately.

### Part 1: Move stateful search-related logic to new `SearchState` class

Create a `SearchState` class to bring distant-but-related search state management logic closer together. This is mainly an aesthetic refactoring but it does also fix some rare bugs, e.g.
- Searches with leading or trailing spaces being re-executed on every frame even if input doesn't change, resulting in the inability to scroll the result list as the position would also reset each frame.
- Adding and removing a ? sigil to move into and out of wiki mode would behave oddly in that mode transitions would sometimes require an additional keypress for the mode change to register.
- History entries stored their sigil as plain text, meaning entries could be lost if the global search mode changed. They now store the exact `SearchCriteria` which was used at the time they were added.

None of these bugs were particularly important or impactful, but the combination of all three plus a desire to keep UI-side logic out of e.g. `FuzzyMatcher` made me want to do this.

### Part 2: Add support for kana normalization

Add a new downcasing method which optionally converts hiragana to katakana. We use this method by default for all `SearchDatabase` entries when the language is set to Japanese. For other kinds of entries, we check if the search term contains kana, and if so we normalize search candidates in the same way. The result is that all underlying matching uses katakana, and hence searches are kana-insensitive in both directions.

Potentially closes issue #34.