### PR TITLE
Include crafting type in crafting recipe results

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1129,13 +1129,26 @@ namespace Dalamud.FindAnything
         }
 
         private class CraftingRecipeResult : ISearchResult, IEquatable<CraftingRecipeResult> {
-            public string CatName => "Crafting Recipe";
+            public string CatName
+            {
+                get
+                {
+                    if (CraftType != null) {
+                        return $"Crafting Recipe ({CraftType.Name.RawString})";
+                    }
+
+                    return "Crafting Recipe";
+                }
+            }
+
             public string Name { get; set; }
             public TextureWrap? Icon { get; set; }
             public int Score { get; set; }
             public bool CloseFinder => true;
 
             public Recipe Recipe { get; set; }
+
+            public CraftType? CraftType { get; set; }
 
             public void Selected() {
                 var id = this.Recipe.ItemResult.Value?.RowId ?? 0;
@@ -1728,6 +1741,7 @@ namespace Dalamud.FindAnything
                                                 Score = score,
                                                 Recipe = recipe,
                                                 Name = recipeSearch.Value.Display,
+                                                CraftType = recipe.CraftType.Value,
                                                 Icon = tex,
                                             });
                                         }


### PR DESCRIPTION
Adds the recipe type to the category name for recipes. So `Crafting Recipe` becomes `Crafting Recipe (Blacksmithing)` etc. There is not much benefit to this but I feel it makes things slightly less weird when a recipe is duplicated multiple times. Now you can look and go "Oh, it's because there are 8 recipes for the same thing", or something like that.