### PR TITLE
Add support for UiBuilder.OpenMain in other plugins

### DIFF
--- a/Dalamud.FindAnything/DalamudReflector.cs
+++ b/Dalamud.FindAnything/DalamudReflector.cs
@@ -16,10 +16,17 @@ public class DalamudReflector
     {
         public string Name { get; set; }
         public UiBuilder UiBuilder { get; set; }
+        public bool HasConfigUi { get; set; }
+        public bool HasMainUi { get; set; }
 
         public void OpenConfigUi()
         {
-            UiBuilder.GetType().GetMethod("OpenConfig", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(UiBuilder, null);
+            UiBuilder.GetType().GetMethod("OpenConfig", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(UiBuilder, null);
+        }
+
+        public void OpenMainUi()
+        {
+            UiBuilder.GetType().GetMethod("OpenMain", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(UiBuilder, null);
         }
     }
 
@@ -48,7 +55,10 @@ public class DalamudReflector
 
             var configUiProp = uib.GetType().GetProperty("HasConfigUi", BindingFlags.NonPublic | BindingFlags.Instance);
             var hasConfigUi = (bool)configUiProp.GetValue(uib);
-            if (!hasConfigUi)
+
+            var mainUiProp = uib.GetType().GetProperty("HasMainUi", BindingFlags.NonPublic | BindingFlags.Instance);
+            var hasMainUi = (bool)mainUiProp.GetValue(uib);
+            if (!hasConfigUi && !hasMainUi)
                 continue;
 
             var name = (string)item.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
@@ -59,8 +69,10 @@ public class DalamudReflector
             
             var entry = new PluginEntry()
             {
-                Name =  name + " Settings",
+                Name =  name,
                 UiBuilder = uib as UiBuilder,
+                HasConfigUi = hasConfigUi,
+                HasMainUi = hasMainUi
             };
             list.Add(entry);
         }

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -635,6 +635,41 @@ namespace Dalamud.FindAnything
             }
         }
 
+        private class PluginInterfaceSearchResult : ISearchResult, IEquatable<PluginInterfaceSearchResult>
+        {
+            public string CatName => "Other Plugins";
+            public string Name { get; set; }
+            public IDalamudTextureWrap? Icon => TexCache.PluginInstallerIcon;
+            public int Score { get; set; }
+            public bool CloseFinder => true;
+            public DalamudReflector.PluginEntry Plugin { get; set; }
+
+            public void Selected()
+            {
+                Plugin.OpenMainUi();
+            }
+
+            public bool Equals(PluginInterfaceSearchResult? other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return this.Plugin.Name.Equals(other.Plugin.Name);
+            }
+
+            public override bool Equals(object? obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((PluginInterfaceSearchResult)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.Plugin.GetHashCode();
+            }
+        }
+
         private class MacroLinkSearchResult : ISearchResult, IEquatable<MacroLinkSearchResult>
         {
             public string CatName => "Macros";
@@ -1652,12 +1687,23 @@ namespace Dalamud.FindAnything
                                         var score = matcher.Matches(plugin.Name.Downcase(normalizeKana));
                                         if (score > 0)
                                         {
-                                            cResults.Add(new PluginSettingsSearchResult
-                                            {
-                                                Score = score,
-                                                Name = plugin.Name,
-                                                Plugin = plugin,
-                                            });
+                                            if (plugin.HasMainUi) {
+                                                cResults.Add(new PluginInterfaceSearchResult
+                                                {
+                                                    Score = score,
+                                                    Name = plugin.Name + " Interface",
+                                                    Plugin = plugin,
+                                                });
+                                            }
+
+                                            if (plugin.HasConfigUi) {
+                                                cResults.Add(new PluginSettingsSearchResult
+                                                {
+                                                    Score = score,
+                                                    Name = plugin.Name + " Settings",
+                                                    Plugin = plugin,
+                                                });
+                                            }
                                         }
                                     }
 


### PR DESCRIPTION
Adds support for `UiBuilder.OpenMain` for other plugins (in addition to `OpenConfig` which is already supported). If both are available, both will be added as separate entries named "Plugin Name Interface" and "Plugin Name Settings".

Right now it looks like the only plugin using this is Pet Nicknames, but I guess others may migrate to it in future.