### PR TITLE
Re-organize settings and address various issues which needed settings changes to support

### DIFF
--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -25,6 +25,8 @@ namespace Dalamud.FindAnything
             SearchSetting.Reserved20 | SearchSetting.Reserved21 | SearchSetting.Reserved22 | SearchSetting.Reserved23 |
             SearchSetting.Reserved24;
 
+        public Dictionary<SearchSetting, int> SearchWeights = new();
+
         public OpenMode Open { get; set; } = OpenMode.Combo;
 
         public uint ShiftShiftDelay { get; set; } = 40;

--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -28,6 +28,12 @@ namespace Dalamud.FindAnything
         public OpenMode Open { get; set; } = OpenMode.Combo;
 
         public uint ShiftShiftDelay { get; set; } = 40;
+        public enum DoubleTapUnit
+        {
+            Frames,
+            Milliseconds,
+        }
+        public DoubleTapUnit ShiftShiftUnit { get; set; } = DoubleTapUnit.Frames;
         public VirtualKey ComboModifier { get; set; } = VirtualKey.CONTROL;
         public VirtualKey ComboModifier2 { get; set; } = VirtualKey.NO_KEY;
         public VirtualKey ComboKey { get; set; } = VirtualKey.T;

--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -118,6 +118,14 @@ namespace Dalamud.FindAnything
 
         public List<MacroEntry> MacroLinks { get; set; } = new();
 
+        public enum MacroSearchDirection
+        {
+            BottomToTop,
+            TopToBottom,
+        }
+
+        public MacroSearchDirection MacroLinksSearchDirection { get; set; } = MacroSearchDirection.BottomToTop;
+
         public bool DoAetheryteGilCost { get; set; } = false;
         public bool DoMarketBoardShortcut { get; set; } = false;
         public bool DoStrikingDummyShortcut { get; set; } = false;

--- a/Dalamud.FindAnything/DalamudReflector.cs
+++ b/Dalamud.FindAnything/DalamudReflector.cs
@@ -16,10 +16,17 @@ public class DalamudReflector
     {
         public string Name { get; set; }
         public UiBuilder UiBuilder { get; set; }
+        public bool HasConfigUi { get; set; }
+        public bool HasMainUi { get; set; }
 
         public void OpenConfigUi()
         {
-            UiBuilder.GetType().GetMethod("OpenConfig", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(UiBuilder, null);
+            UiBuilder.GetType().GetMethod("OpenConfig", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(UiBuilder, null);
+        }
+
+        public void OpenMainUi()
+        {
+            UiBuilder.GetType().GetMethod("OpenMain", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(UiBuilder, null);
         }
     }
 
@@ -48,7 +55,10 @@ public class DalamudReflector
 
             var configUiProp = uib.GetType().GetProperty("HasConfigUi", BindingFlags.NonPublic | BindingFlags.Instance);
             var hasConfigUi = (bool)configUiProp.GetValue(uib);
-            if (!hasConfigUi)
+
+            var mainUiProp = uib.GetType().GetProperty("HasMainUi", BindingFlags.NonPublic | BindingFlags.Instance);
+            var hasMainUi = (bool)mainUiProp.GetValue(uib);
+            if (!hasConfigUi && !hasMainUi)
                 continue;
 
             var name = (string)item.GetType().GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
@@ -59,8 +69,10 @@ public class DalamudReflector
             
             var entry = new PluginEntry()
             {
-                Name =  name + " Settings",
+                Name =  name,
                 UiBuilder = uib as UiBuilder,
+                HasConfigUi = hasConfigUi,
+                HasMainUi = hasMainUi
             };
             list.Add(entry);
         }

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -635,6 +635,41 @@ namespace Dalamud.FindAnything
             }
         }
 
+        private class PluginInterfaceSearchResult : ISearchResult, IEquatable<PluginInterfaceSearchResult>
+        {
+            public string CatName => "Other Plugins";
+            public string Name { get; set; }
+            public IDalamudTextureWrap? Icon => TexCache.PluginInstallerIcon;
+            public int Score { get; set; }
+            public bool CloseFinder => true;
+            public DalamudReflector.PluginEntry Plugin { get; set; }
+
+            public void Selected()
+            {
+                Plugin.OpenMainUi();
+            }
+
+            public bool Equals(PluginInterfaceSearchResult? other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return this.Plugin.Name.Equals(other.Plugin.Name);
+            }
+
+            public override bool Equals(object? obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((PluginInterfaceSearchResult)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.Plugin.GetHashCode();
+            }
+        }
+
         private class MacroLinkSearchResult : ISearchResult, IEquatable<MacroLinkSearchResult>
         {
             public string CatName => "Macros";
@@ -1652,12 +1687,23 @@ namespace Dalamud.FindAnything
                                         var score = matcher.Matches(plugin.Name.Downcase(normalizeKana));
                                         if (score > 0)
                                         {
-                                            cResults.Add(new PluginSettingsSearchResult
-                                            {
-                                                Score = score,
-                                                Name = plugin.Name,
-                                                Plugin = plugin,
-                                            });
+                                            if (plugin.HasMainUi) {
+                                                cResults.Add(new PluginInterfaceSearchResult
+                                                {
+                                                    Score = score,
+                                                    Name = plugin.Name + " Interface",
+                                                    Plugin = plugin,
+                                                });
+                                            }
+
+                                            if (plugin.HasConfigUi) {
+                                                cResults.Add(new PluginSettingsSearchResult
+                                                {
+                                                    Score = score,
+                                                    Name = plugin.Name + " Settings",
+                                                    Plugin = plugin,
+                                                });
+                                            }
                                         }
                                     }
 

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -139,6 +139,7 @@ namespace Dalamud.FindAnything
 
         private static List<HistoryEntry> history = new();
         private const int HistoryMax = 5;
+        internal const int DefaultWeight = 100;
 
         private interface ISearchResult
         {
@@ -1460,8 +1461,8 @@ namespace Dalamud.FindAnything
             {
                 case SearchMode.Top:
                 {
-                    foreach (var setting in Configuration.Order)
-                    {
+                    foreach (var setting in Configuration.Order) {
+                        var weight = Configuration.SearchWeights.GetValueOrDefault(setting, DefaultWeight);
                         switch (setting)
                         {
                             case Configuration.SearchSetting.Duty:
@@ -1501,7 +1502,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new DutySearchResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 CatName = row.ContentType?.Value?.Name ?? "Duty",
                                                 DataKey = cfc.Key,
                                                 Name = cfc.Value.Display,
@@ -1526,7 +1527,7 @@ namespace Dalamud.FindAnything
 
                                             cResults.Add(new ContentRouletteSearchResult()
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 DataKey = (byte) contentRoulette.RowId,
                                                 Name = name,
                                             });
@@ -1555,7 +1556,7 @@ namespace Dalamud.FindAnything
                                         if (score > 0)
                                             cResults.Add(new AetheryteSearchResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Name = aetheryteName,
                                                 Data = aetheryte,
                                                 Icon = TexCache.AetheryteIcon,
@@ -1579,7 +1580,7 @@ namespace Dalamud.FindAnything
                                         var terriName = SearchDatabase.GetString<TerritoryType>(closestMarketBoard.TerritoryId);
                                         cResults.Add(new AetheryteSearchResult
                                         {
-                                            Score = marketScore,
+                                            Score = marketScore * weight,
                                             Name = "Closest Market Board",
                                             Data = closestMarketBoard,
                                             Icon = TexCache.AetheryteIcon,
@@ -1592,7 +1593,7 @@ namespace Dalamud.FindAnything
                                         var terriName = SearchDatabase.GetString<TerritoryType>(closestStrikingDummy.TerritoryId);
                                         cResults.Add(new AetheryteSearchResult
                                         {
-                                            Score = dummyScore,
+                                            Score = dummyScore * weight,
                                             Name = "Closest Striking Dummy",
                                             Data = closestStrikingDummy,
                                             Icon = TexCache.AetheryteIcon,
@@ -1619,7 +1620,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new MainCommandSearchResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 CommandId = mainCommand.Key,
                                                 Name = mainCommand.Value.Display,
                                                 Icon = TexCache.MainCommandIcons[mainCommand.Key]
@@ -1655,7 +1656,7 @@ namespace Dalamud.FindAnything
                                             if (score > 0)
                                                 cResults.Add(new GeneralActionSearchResult
                                                 {
-                                                    Score = score,
+                                                    Score = score * weight,
                                                     Name = generalAction.Value.Display,
                                                     Icon = TexCache.GeneralActionIcons[generalAction.Key]
                                                 });
@@ -1682,7 +1683,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new EmoteSearchResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Name = text.Display,
                                                 SlashCommand = slashCmd.Command.RawString,
                                                 Icon = TexCache.EmoteIcons[emoteRow.RowId]
@@ -1707,7 +1708,7 @@ namespace Dalamud.FindAnything
                                             if (plugin.HasMainUi) {
                                                 cResults.Add(new PluginInterfaceSearchResult
                                                 {
-                                                    Score = score,
+                                                    Score = score * weight,
                                                     Name = plugin.Name + " Interface",
                                                     Plugin = plugin,
                                                 });
@@ -1716,7 +1717,7 @@ namespace Dalamud.FindAnything
                                             if (plugin.HasConfigUi) {
                                                 cResults.Add(new PluginSettingsSearchResult
                                                 {
-                                                    Score = score,
+                                                    Score = score * weight,
                                                     Name = plugin.Name + " Settings",
                                                     Plugin = plugin,
                                                 });
@@ -1733,7 +1734,7 @@ namespace Dalamud.FindAnything
                                             {
                                                 cResults.Add(new IpcSearchResult
                                                 {
-                                                    Score = score,
+                                                    Score = score * weight,
                                                     CatName = plugin.Key,
                                                     Name = ipcBinding.Display,
                                                     Guid = ipcBinding.Guid,
@@ -1766,7 +1767,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new GearsetSearchResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Gearset = gearset,
                                             });
                                         }
@@ -1788,7 +1789,7 @@ namespace Dalamud.FindAnything
 
                                             cResults.Add(new CraftingRecipeResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Recipe = recipe,
                                                 Name = recipeSearch.Value.Display,
                                                 Icon = tex,
@@ -1821,7 +1822,7 @@ namespace Dalamud.FindAnything
 
                                             cResults.Add(new GatheringItemResult()
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Item = gather,
                                                 Name = gatherSearch.Value.Display,
                                                 Icon = tex,
@@ -1858,7 +1859,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new MountResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Mount = mount,
                                             });
                                         }
@@ -1881,7 +1882,7 @@ namespace Dalamud.FindAnything
                                         {
                                             cResults.Add(new MinionResult
                                             {
-                                                Score = score,
+                                                Score = score * weight,
                                                 Minion = minion,
                                             });
                                         }
@@ -1901,7 +1902,7 @@ namespace Dalamud.FindAnything
                                     {
                                         cResults.Add(new MacroLinkSearchResult
                                         {
-                                            Score = score,
+                                            Score = score * weight,
                                             Entry = macroLink,
                                         });
                                     }
@@ -1915,7 +1916,7 @@ namespace Dalamud.FindAnything
                                     {
                                         cResults.Add(new InternalSearchResult
                                         {
-                                            Score = score,
+                                            Score = score * weight,
                                             Kind = kind
                                         });
                                     }
@@ -2035,7 +2036,7 @@ namespace Dalamud.FindAnything
 
                         var score = matcher.Matches("dn farm");
                         if (score > 0)
-                            cResults.Add(new GameSearchResult { Score = score });
+                            cResults.Add(new GameSearchResult { Score = score * DefaultWeight });
                     }
                 }
                     break;

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1872,7 +1872,12 @@ namespace Dalamud.FindAnything
                                 }
                                 break;
                             case Configuration.SearchSetting.MacroLinks:
-                                foreach (var macroLink in Configuration.MacroLinks)
+                                var macroLinks = Configuration.MacroLinks.AsEnumerable();
+                                if (Configuration.MacroLinksSearchDirection == Configuration.MacroSearchDirection.TopToBottom) {
+                                    macroLinks = macroLinks.Reverse();
+                                }
+
+                                foreach (var macroLink in macroLinks)
                                 {
                                     var score = matcher.Matches(macroLink.SearchName.Downcase(normalizeKana));
                                     if (score > 0)

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -21,6 +21,7 @@ public class SettingsWindow : Window
     private Configuration.OpenMode openMode;
     private VirtualKey shiftShiftKey;
     private int shiftShiftDelay;
+    private Configuration.DoubleTapUnit shiftShiftUnit;
     private VirtualKey comboModifierKey;
     private VirtualKey comboModifier2Key;
     private VirtualKey comboKey;
@@ -68,6 +69,7 @@ public class SettingsWindow : Window
         this.openMode = FindAnythingPlugin.Configuration.Open;
         this.shiftShiftKey = FindAnythingPlugin.Configuration.ShiftShiftKey;
         this.shiftShiftDelay = (int) FindAnythingPlugin.Configuration.ShiftShiftDelay;
+        this.shiftShiftUnit = FindAnythingPlugin.Configuration.ShiftShiftUnit;
         this.comboKey = FindAnythingPlugin.Configuration.ComboKey;
         this.comboModifierKey = FindAnythingPlugin.Configuration.ComboModifier;
         this.comboModifier2Key = FindAnythingPlugin.Configuration.ComboModifier2;
@@ -122,10 +124,26 @@ public class SettingsWindow : Window
                     case Configuration.OpenMode.ShiftShift:
                         VirtualKeySelect("Key to double tap", ref shiftShiftKey);
 
-                        if (ImGui.InputInt("Delay (ms)", ref shiftShiftDelay)) {
+                        // ImGui.PushItemWidth(200);
+                        ImGui.PushItemWidth(ImGui.GetWindowWidth() * 0.2f);
+
+                        if (ImGui.InputInt("", ref shiftShiftDelay)) {
                             shiftShiftDelay = Math.Max(shiftShiftDelay, 0);
                         }
 
+                        ImGui.SameLine();
+
+                        if (ImGui.BeginCombo("Delay", shiftShiftUnit.ToString())) {
+                            foreach (var key in Enum.GetValues<Configuration.DoubleTapUnit>()) {
+                                if (ImGui.Selectable(key.ToString(), key == shiftShiftUnit)) {
+                                    shiftShiftUnit = key;
+                                }
+                            }
+
+                            ImGui.EndCombo();
+                        }
+
+                        ImGui.PopItemWidth();
                         break;
                     case Configuration.OpenMode.Combo:
                         VirtualKeySelect("Combo Modifier 1", ref comboModifierKey);
@@ -360,6 +378,7 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.Open = openMode;
             FindAnythingPlugin.Configuration.ShiftShiftKey = shiftShiftKey;
             FindAnythingPlugin.Configuration.ShiftShiftDelay = (uint) shiftShiftDelay;
+            FindAnythingPlugin.Configuration.ShiftShiftUnit = shiftShiftUnit;
 
             FindAnythingPlugin.Configuration.ComboKey = comboKey;
             FindAnythingPlugin.Configuration.ComboModifier = comboModifierKey;

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -40,6 +40,7 @@ public class SettingsWindow : Window
     private bool onlyWiki;
     private VirtualKey quickSelectKey;
     private List<Configuration.SearchSetting> order = new();
+    private Dictionary<Configuration.SearchSetting, int> searchWeights = new();
     private Configuration.ScrollSpeed speed;
     private bool notInCombat;
     private bool tcForceBrowser;
@@ -88,6 +89,7 @@ public class SettingsWindow : Window
         this.onlyWiki = FindAnythingPlugin.Configuration.OnlyWikiMode;
         this.quickSelectKey = FindAnythingPlugin.Configuration.QuickSelectKey;
         this.order = FindAnythingPlugin.Configuration.Order.ToList();
+        this.searchWeights = new Dictionary<Configuration.SearchSetting, int>(FindAnythingPlugin.Configuration.SearchWeights);
         this.speed = FindAnythingPlugin.Configuration.Speed;
         this.notInCombat = FindAnythingPlugin.Configuration.NotInCombat;
         this.tcForceBrowser = FindAnythingPlugin.Configuration.TeamCraftForceBrowser;
@@ -261,6 +263,13 @@ public class SettingsWindow : Window
                     ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
                 ImGui.TextColored(ImGuiColors.DalamudGrey, "What to search");
 
+                ImGui.Columns(2);
+                ImGui.SetColumnWidth(0, 300 + 5 * ImGuiHelpers.GlobalScale);
+                ImGui.SetColumnWidth(1, 200 + 5 * ImGuiHelpers.GlobalScale);
+
+                ImGui.Separator();
+
+                ImGui.Text("Search order");
                 ImGui.SameLine();
                 ImGuiComponents.HelpMarker(
                     "When using the default \"Simple\" search mode, results will appear in the order defined " +
@@ -269,7 +278,21 @@ public class SettingsWindow : Window
                     "the order defined below will be used only for tie-breaks (when multiple results match " +
                     "equally well).\n\n" +
                     "Un-ticking a check box will cause all entries from that category to be ignored in any mode.");
+                ImGui.NextColumn();
 
+                ImGui.Text("Weight");
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    "The weight setting for each category can be used to adjust the internal match score " +
+                    "calculated for results when using fuzzy search modes. When compared to the default weight " +
+                    "of 100, for example, a category with a weight of 200 will have its match scores doubled " +
+                    "while a category with a weight of 50 will have them halved.\n\n" +
+                    "Search results with higher weightings tend to have higher match scores, and therefore " +
+                    "appear higher in the results list.\n\n" +
+                    "Weights are ignored when using the \"Simple\" search mode.");
+                ImGui.NextColumn();
+
+                ImGui.Separator();
 
                 for (var i = 0; i < this.order.Count; i++) {
                     var search = this.order[i];
@@ -301,14 +324,13 @@ public class SettingsWindow : Window
 
                     ImGui.PushFont(UiBuilder.IconFont);
 
-                    if (ImGui.Button($"{FontAwesomeIcon.ArrowUp.ToIconString()}##{search}") && i != 0) {
+                    if (IconButtonEnabledWhen(i != 0, FontAwesomeIcon.ArrowUp, $"{search}")) {
                         (this.order[i], this.order[i - 1]) = (this.order[i - 1], this.order[i]);
                     }
 
                     ImGui.SameLine();
 
-                    if (ImGui.Button($"{FontAwesomeIcon.ArrowDown.ToIconString()}##{search}") &&
-                        i != this.order.Count - 1) {
+                    if (IconButtonEnabledWhen(i != this.order.Count - 1, FontAwesomeIcon.ArrowDown, $"{search}")) {
                         (this.order[i], this.order[i + 1]) = (this.order[i + 1], this.order[i]);
                     }
 
@@ -317,15 +339,43 @@ public class SettingsWindow : Window
                     ImGui.SameLine();
 
                     if (isRequired) {
-                        ImGui.TextUnformatted($"Search in {name}");
+                        var locked = true;
+                        ImGui.PushStyleColor(ImGuiCol.FrameBg, Vector4.Zero);
+                        ImGui.PushStyleColor(ImGuiCol.FrameBgActive, Vector4.Zero);
+                        ImGui.PushStyleColor(ImGuiCol.FrameBgHovered, Vector4.Zero);
+                        ImGui.PushStyleColor(ImGuiCol.CheckMark, ImGuiColors.ParsedGrey);
+                        ImGui.Checkbox($"Search in {name}", ref locked);
+                        ImGui.PopStyleColor(4);
                     }
                     else {
                         ImGui.CheckboxFlags($"Search in {name}", ref this.flags, (uint)search);
                     }
+
+                    ImGui.NextColumn();
+
+                    ImGui.PushItemWidth(120);
+                    var weight = searchWeights.GetValueOrDefault(search, FindAnythingPlugin.DefaultWeight);
+                    if (ImGui.InputInt($"##{search}-weight", ref weight, FindAnythingPlugin.DefaultWeight / 10, FindAnythingPlugin.DefaultWeight)) {
+                        if (weight is > 0 and < FindAnythingPlugin.DefaultWeight * 1000) {
+                            if (weight == FindAnythingPlugin.DefaultWeight) {
+                                searchWeights.Remove(search);
+                            }
+                            else {
+                                searchWeights[search] = weight;
+                            }
+                        }
+                    }
+                    ImGui.PopItemWidth();
+
+                    ImGui.Separator();
+                    ImGui.NextColumn();
                 }
 
                 ImGui.CheckboxFlags("Mathematical Expressions", ref this.flags,
                     (uint)Configuration.SearchSetting.Maths);
+                ImGui.Separator();
+
+                ImGui.Columns(1);
 
                 ImGui.EndChild();
                 ImGui.EndTabItem();
@@ -374,6 +424,7 @@ public class SettingsWindow : Window
         {
             FindAnythingPlugin.Configuration.ToSearchV3 = (Configuration.SearchSetting) this.flags;
             FindAnythingPlugin.Configuration.Order = this.order;
+            FindAnythingPlugin.Configuration.SearchWeights = this.searchWeights;
 
             FindAnythingPlugin.Configuration.Open = openMode;
             FindAnythingPlugin.Configuration.ShiftShiftKey = shiftShiftKey;

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -7,6 +7,8 @@ using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Windowing;
+using Dalamud.Logging;
+using Dalamud.Utility.Numerics;
 using ImGuiNET;
 using Newtonsoft.Json;
 
@@ -25,6 +27,7 @@ public class SettingsWindow : Window
     private VirtualKey wikiComboKey;
     private bool preventPassthrough;
     private List<Configuration.MacroEntry> macros = new();
+    private Configuration.MacroSearchDirection macroLinksSearch;
     private bool aetheryteGilCost;
     private bool marketBoardShortcut;
     private bool strikingDummyShortcut;
@@ -45,6 +48,7 @@ public class SettingsWindow : Window
     private string matchSigilFuzzy;
     private string matchSigilFuzzyParts;
 
+    private bool macroRearrangeMode;
     private const int SaveDiscardOffset = -40;
 
     public SettingsWindow(FindAnythingPlugin plugin) : base("Wotsit Settings")
@@ -70,6 +74,7 @@ public class SettingsWindow : Window
         this.wikiComboKey = FindAnythingPlugin.Configuration.WikiComboKey;
         this.preventPassthrough = FindAnythingPlugin.Configuration.PreventPassthrough;
         this.macros = FindAnythingPlugin.Configuration.MacroLinks.Select(x => new Configuration.MacroEntry(x)).ToList();
+        this.macroLinksSearch = FindAnythingPlugin.Configuration.MacroLinksSearchDirection;
         this.aetheryteGilCost = FindAnythingPlugin.Configuration.DoAetheryteGilCost;
         this.marketBoardShortcut = FindAnythingPlugin.Configuration.DoMarketBoardShortcut;
         this.strikingDummyShortcut = FindAnythingPlugin.Configuration.DoStrikingDummyShortcut;
@@ -89,6 +94,8 @@ public class SettingsWindow : Window
         this.matchSigilSimple = FindAnythingPlugin.Configuration.MatchSigilSimple;
         this.matchSigilFuzzy = FindAnythingPlugin.Configuration.MatchSigilFuzzy;
         this.matchSigilFuzzyParts = FindAnythingPlugin.Configuration.MatchSigilFuzzyParts;
+
+        this.macroRearrangeMode = false;
         base.OnOpen();
     }
 
@@ -311,10 +318,24 @@ public class SettingsWindow : Window
                     ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
 
                 ImGui.TextColored(ImGuiColors.DalamudGrey, "Macro links");
-                ImGui.TextWrapped(
-                    "Use this menu to tie search results to macros.\nClick \"Add Macro\", enter the text you want to access it under, select whether or not it is a shared macro and enter its ID.\nUse the ';' character to add search text for a macro, only the first part text will be shown, e.g. \"SGE;sage;healer\".");
 
                 DrawMacrosSection();
+
+                ImGuiHelpers.ScaledDummy(15);
+                ImGui.Separator();
+                ImGuiHelpers.ScaledDummy(15);
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Search direction");
+                ImGui.TextWrapped(
+                    "Use this to change the order in which macro links are searched. This may affect which macro links are displayed higher in the result list.");
+
+                if (ImGui.RadioButton("Top to bottom", macroLinksSearch == Configuration.MacroSearchDirection.TopToBottom)) {
+                    macroLinksSearch = Configuration.MacroSearchDirection.TopToBottom;
+                }
+
+                if (ImGui.RadioButton("Bottom to top", macroLinksSearch == Configuration.MacroSearchDirection.BottomToTop)) {
+                    macroLinksSearch = Configuration.MacroSearchDirection.BottomToTop;
+                }
 
                 ImGui.EndChild();
                 ImGui.EndTabItem();
@@ -347,6 +368,7 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.PreventPassthrough = preventPassthrough;
 
             FindAnythingPlugin.Configuration.MacroLinks = this.macros;
+            FindAnythingPlugin.Configuration.MacroLinksSearchDirection = this.macroLinksSearch;
 
             FindAnythingPlugin.Configuration.DoAetheryteGilCost = this.aetheryteGilCost;
             FindAnythingPlugin.Configuration.DoMarketBoardShortcut = this.marketBoardShortcut;
@@ -382,199 +404,278 @@ public class SettingsWindow : Window
         }
     }
 
+    private int dropSource = -1;
+
     private void DrawMacrosSection()
     {
-        ImGui.Columns(6);
-        ImGui.SetColumnWidth(0, 200 + 5 * ImGuiHelpers.GlobalScale);
-        ImGui.SetColumnWidth(1, 140 + 5 * ImGuiHelpers.GlobalScale);
-        ImGui.SetColumnWidth(2, 80 + 5 * ImGuiHelpers.GlobalScale);
-        ImGui.SetColumnWidth(3, 160 + 5 * ImGuiHelpers.GlobalScale);
-        ImGui.SetColumnWidth(4, 160 + 5 * ImGuiHelpers.GlobalScale);
-        ImGui.SetColumnWidth(5, 30 + 5 * ImGuiHelpers.GlobalScale);
+        if (macroRearrangeMode) {
+            ImGui.TextWrapped("Use arrows or drag and drop macros to change the order.");
 
-        ImGui.Separator();
+            for (var macroNumber = macros.Count - 1; macroNumber >= 0; macroNumber--) {
+                var name = macros[macroNumber].SearchName;
+                var size = ImGuiHelpers.GetButtonSize(name).WithX(300f);
+                ImGui.PushStyleVar(ImGuiStyleVar.ButtonTextAlign, new Vector2(0f, 0.5f));
+                ImGui.Button($"{macros[macroNumber].SearchName}###b{macroNumber}", size);
 
-        ImGui.Text("Search Name");
-        ImGui.NextColumn();
-        ImGui.Text("Kind");
-        ImGui.NextColumn();
-        ImGui.Text("Shared");
-        ImGui.NextColumn();
-        ImGui.Text("ID/Line");
-        ImGui.NextColumn();
-        ImGui.Text("Icon");
-        ImGui.NextColumn();
-        ImGui.Text(string.Empty);
-        ImGui.NextColumn();
-
-        ImGui.Separator();
-
-        for (var macroNumber = this.macros.Count - 1; macroNumber >= 0; macroNumber--)
-        {
-            var macro = this.macros[macroNumber];
-            ImGui.PushID($"macro_{macroNumber}");
-
-            ImGui.SetNextItemWidth(-1);
-
-            var text = macro.SearchName;
-            if (ImGui.InputText($"###macroSn", ref text, 100))
-            {
-                macro.SearchName = text;
-            }
-
-            ImGui.NextColumn();
-
-            if (ImGui.BeginCombo("###macroKnd", macro.Kind.ToString()))
-            {
-                foreach (var macroEntryKind in Enum.GetValues<Configuration.MacroEntry.MacroEntryKind>())
-                {
-                    if (ImGui.Selectable(macroEntryKind.ToString(), macroEntryKind == macro.Kind))
-                    {
-                        macro.Kind = macroEntryKind;
-                    }
+                if (ImGui.BeginDragDropSource()) {
+                    ImGui.SetDragDropPayload("MACRO", IntPtr.Zero, 0);
+                    ImGui.Button($"{macros[macroNumber].SearchName}###d{macroNumber}", size);
+                    dropSource = macroNumber;
+                    ImGui.EndDragDropSource();
                 }
-                ImGui.EndCombo();
-            }
 
-            ImGui.NextColumn();
+                if (ImGui.BeginDragDropTarget()) {
+                    ImGui.AcceptDragDropPayload("MACRO");
+                    if (ImGui.IsMouseReleased(ImGuiMouseButton.Left)) {
+                        var moving = macros[dropSource];
+                        macros.RemoveAt(dropSource);
+                        macros.Insert(macroNumber, moving);
+                    }
 
-            if (macro.Kind == Configuration.MacroEntry.MacroEntryKind.Id)
-            {
-                var isShared = macro.Shared;
-                if (ImGui.Checkbox($"###macroSh", ref isShared))
-                {
-                    macro.Shared = isShared;
+                    ImGui.EndDragDropTarget();
+                }
+
+                ImGui.PopStyleVar();
+
+                ImGui.SameLine();
+
+                if (IconButtonEnabledWhen(macroNumber <= macros.Count - 2, FontAwesomeIcon.AngleDoubleUp,
+                        $"macro-top-{macroNumber}")) {
+                    var moving = macros[macroNumber];
+                    macros.RemoveAt(macroNumber);
+                    macros.Add(moving);
+                }
+                if (ImGui.IsItemHovered()) {
+                    ImGui.SetTooltip("Move to top");
+                }
+
+                ImGui.SameLine();
+
+                if (IconButtonEnabledWhen(macroNumber <= macros.Count - 2, FontAwesomeIcon.ArrowUp,
+                        $"macro-up-{macroNumber}")) {
+                    macros.Reverse(macroNumber, 2);
+                }
+                if (ImGui.IsItemHovered()) {
+                    ImGui.SetTooltip("Move up");
+                }
+
+                ImGui.SameLine();
+
+                if (IconButtonEnabledWhen(macroNumber >= 1, FontAwesomeIcon.ArrowDown, $"macro-down-{macroNumber}")) {
+                    macros.Reverse(macroNumber - 1, 2);
+                }
+                if (ImGui.IsItemHovered()) {
+                    ImGui.SetTooltip("Move down");
+                }
+
+                ImGui.SameLine();
+
+                if (IconButtonEnabledWhen(macroNumber >= 1, FontAwesomeIcon.AngleDoubleDown,
+                        $"macro-bottom-{macroNumber}")) {
+                    var moving = macros[macroNumber];
+                    macros.RemoveAt(macroNumber);
+                    macros.Insert(0, moving);
+                }
+                if (ImGui.IsItemHovered()) {
+                    ImGui.SetTooltip("Move to bottom");
                 }
             }
-            else
-            {
-                ImGui.PushStyleColor(ImGuiCol.FrameBg, ImGuiColors.ParsedGrey);
-                ImGui.PushStyleColor(ImGuiCol.FrameBgActive, ImGuiColors.ParsedGrey);
-                ImGui.PushStyleColor(ImGuiCol.FrameBgHovered, ImGuiColors.ParsedGrey);
-                ImGui.PushStyleColor(ImGuiCol.CheckMark, ImGuiColors.ParsedGrey);
 
-                var isShared = false;
-                ImGui.Checkbox("###macroSh", ref isShared);
-
-                ImGui.PopStyleColor(4);
+            ImGuiHelpers.ScaledDummy(15);
+            if (ImGui.Button("Stop rearranging")) {
+                macroRearrangeMode = false;
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Reverse all")) {
+                macros.Reverse();
             }
 
+        }
+        else {
+            ImGui.TextWrapped(
+                "Use this menu to tie search results to macros.\nClick \"Add Macro\", enter the text you want to access it under, select whether or not it is a shared macro and enter its ID.\nUse the ';' character to add search text for a macro, only the first part text will be shown, e.g. \"SGE;sage;healer\".");
 
-            ImGui.NextColumn();
+            ImGui.Columns(6);
+            ImGui.SetColumnWidth(0, 200 + 5 * ImGuiHelpers.GlobalScale);
+            ImGui.SetColumnWidth(1, 140 + 5 * ImGuiHelpers.GlobalScale);
+            ImGui.SetColumnWidth(2, 80 + 5 * ImGuiHelpers.GlobalScale);
+            ImGui.SetColumnWidth(3, 160 + 5 * ImGuiHelpers.GlobalScale);
+            ImGui.SetColumnWidth(4, 160 + 5 * ImGuiHelpers.GlobalScale);
+            ImGui.SetColumnWidth(5, 30 + 5 * ImGuiHelpers.GlobalScale);
 
-            switch (macro.Kind)
-            {
-                case Configuration.MacroEntry.MacroEntryKind.Id:
-                    ImGui.SetNextItemWidth(-1);
-
-                    var id = macro.Id;
-                    if (ImGui.InputInt($"###macroId", ref id))
-                    {
-                        id = Math.Max(0, id);
-                        id = Math.Min(99, id);
-                        macro.Id = id;
-                    }
-
-                    break;
-                case Configuration.MacroEntry.MacroEntryKind.SingleLine:
-                    var line = macro.Line;
-                    line ??= string.Empty;
-                    var didColor = false;
-                    if (!line.StartsWith("/"))
-                    {
-                        didColor = true;
-                        ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
-                    }
-
-                    ImGui.SetNextItemWidth(-1);
-
-                    if (ImGui.InputText($"###macroId", ref line, 100))
-                    {
-                        macro.Line = line;
-                    }
-
-                    if (didColor)
-                    {
-                        ImGui.PopStyleColor();
-                    }
-
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-
-            ImGui.NextColumn();
-
-            var icon = macro.IconId;
-
-            ImGui.SetNextItemWidth(-1);
-
-            if (ImGui.InputInt($"###macroIcon", ref icon))
-            {
-                icon = Math.Max(0, icon);
-                macro.IconId = icon;
-            }
-
-            ImGui.NextColumn();
-
-            this.macros[macroNumber] = macro;
-
-            if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash)) this.macros.RemoveAt(macroNumber);
-
-            ImGui.PopID();
-
-            ImGui.NextColumn();
             ImGui.Separator();
+
+            ImGui.Text("Search Name");
+            ImGui.NextColumn();
+            ImGui.Text("Kind");
+            ImGui.NextColumn();
+            ImGui.Text("Shared");
+            ImGui.NextColumn();
+            ImGui.Text("ID/Line");
+            ImGui.NextColumn();
+            ImGui.Text("Icon");
+            ImGui.NextColumn();
+            ImGui.Text(string.Empty);
+            ImGui.NextColumn();
+
+            ImGui.Separator();
+
+            for (var macroNumber = this.macros.Count - 1; macroNumber >= 0; macroNumber--) {
+                var macro = this.macros[macroNumber];
+                ImGui.PushID($"macro_{macroNumber}");
+
+                ImGui.SetNextItemWidth(-1);
+
+                var text = macro.SearchName;
+                if (ImGui.InputText($"###macroSn", ref text, 100)) {
+                    macro.SearchName = text;
+                }
+
+                ImGui.NextColumn();
+
+                if (ImGui.BeginCombo("###macroKnd", macro.Kind.ToString())) {
+                    foreach (var macroEntryKind in Enum.GetValues<Configuration.MacroEntry.MacroEntryKind>()) {
+                        if (ImGui.Selectable(macroEntryKind.ToString(), macroEntryKind == macro.Kind)) {
+                            macro.Kind = macroEntryKind;
+                        }
+                    }
+
+                    ImGui.EndCombo();
+                }
+
+                ImGui.NextColumn();
+
+                if (macro.Kind == Configuration.MacroEntry.MacroEntryKind.Id) {
+                    var isShared = macro.Shared;
+                    if (ImGui.Checkbox($"###macroSh", ref isShared)) {
+                        macro.Shared = isShared;
+                    }
+                }
+                else {
+                    ImGui.PushStyleColor(ImGuiCol.FrameBg, ImGuiColors.ParsedGrey);
+                    ImGui.PushStyleColor(ImGuiCol.FrameBgActive, ImGuiColors.ParsedGrey);
+                    ImGui.PushStyleColor(ImGuiCol.FrameBgHovered, ImGuiColors.ParsedGrey);
+                    ImGui.PushStyleColor(ImGuiCol.CheckMark, ImGuiColors.ParsedGrey);
+
+                    var isShared = false;
+                    ImGui.Checkbox("###macroSh", ref isShared);
+
+                    ImGui.PopStyleColor(4);
+                }
+
+
+                ImGui.NextColumn();
+
+                switch (macro.Kind) {
+                    case Configuration.MacroEntry.MacroEntryKind.Id:
+                        ImGui.SetNextItemWidth(-1);
+
+                        var id = macro.Id;
+                        if (ImGui.InputInt($"###macroId", ref id)) {
+                            id = Math.Max(0, id);
+                            id = Math.Min(99, id);
+                            macro.Id = id;
+                        }
+
+                        break;
+                    case Configuration.MacroEntry.MacroEntryKind.SingleLine:
+                        var line = macro.Line;
+                        line ??= string.Empty;
+                        var didColor = false;
+                        if (!line.StartsWith("/")) {
+                            didColor = true;
+                            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+                        }
+
+                        ImGui.SetNextItemWidth(-1);
+
+                        if (ImGui.InputText($"###macroId", ref line, 100)) {
+                            macro.Line = line;
+                        }
+
+                        if (didColor) {
+                            ImGui.PopStyleColor();
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                ImGui.NextColumn();
+
+                var icon = macro.IconId;
+
+                ImGui.SetNextItemWidth(-1);
+
+                if (ImGui.InputInt($"###macroIcon", ref icon)) {
+                    icon = Math.Max(0, icon);
+                    macro.IconId = icon;
+                }
+
+                ImGui.NextColumn();
+
+                this.macros[macroNumber] = macro;
+
+                if (ImGuiComponents.IconButton(FontAwesomeIcon.Trash)) this.macros.RemoveAt(macroNumber);
+
+                ImGui.PopID();
+
+                ImGui.NextColumn();
+                ImGui.Separator();
+            }
+
+            ImGui.NextColumn();
+            ImGui.NextColumn();
+            ImGui.NextColumn();
+            ImGui.NextColumn();
+
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.Plus)) {
+                this.macros.Insert(0, new Configuration.MacroEntry
+                {
+                    Id = 0,
+                    SearchName = "New Macro",
+                    Shared = false,
+                    IconId = 066001,
+                    Line = string.Empty,
+                });
+            }
+
+            if (ImGui.IsItemHovered()) {
+                ImGui.SetTooltip("Add new macro link");
+            }
+
+            ImGui.SameLine();
+
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.Copy)) {
+                var json = JsonConvert.SerializeObject(this.macros);
+                ImGui.SetClipboardText("WM1" + json);
+            }
+
+            if (ImGui.IsItemHovered()) {
+                ImGui.SetTooltip("Copy macro links to clipboard");
+            }
+
+            ImGui.SameLine();
+
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.FileImport)) {
+                ImportMacros(ImGui.GetClipboardText());
+            }
+
+            if (ImGui.IsItemHovered()) {
+                ImGui.SetTooltip("Import macro links from clipboard");
+            }
+
+            ImGui.SameLine();
+            if (ImGuiComponents.IconButton(FontAwesomeIcon.ArrowsUpDown)) {
+                macroRearrangeMode = true;
+            }
+            if (ImGui.IsItemHovered()) {
+                ImGui.SetTooltip("Rearrange macro links");
+            }
+
+            ImGui.Columns(1);
         }
-
-        ImGui.NextColumn();
-        ImGui.NextColumn();
-        ImGui.NextColumn();
-        ImGui.NextColumn();
-
-        if (ImGuiComponents.IconButton(FontAwesomeIcon.Plus))
-        {
-            this.macros.Insert(0, new Configuration.MacroEntry
-            {
-                Id = 0,
-                SearchName = "New Macro",
-                Shared = false,
-                IconId = 066001,
-                Line = string.Empty,
-            });
-        }
-
-        if (ImGui.IsItemHovered())
-        {
-            ImGui.SetTooltip("Add new macro link");
-        }
-
-        ImGui.SameLine();
-
-        if (ImGuiComponents.IconButton(FontAwesomeIcon.Copy))
-        {
-            var json = JsonConvert.SerializeObject(this.macros);
-            ImGui.SetClipboardText("WM1" + json);
-        }
-
-        if (ImGui.IsItemHovered())
-        {
-            ImGui.SetTooltip("Copy macro links to clipboard");
-        }
-
-        ImGui.SameLine();
-
-        if (ImGuiComponents.IconButton(FontAwesomeIcon.FileImport))
-        {
-            ImportMacros(ImGui.GetClipboardText());
-        }
-
-        if (ImGui.IsItemHovered())
-        {
-            ImGui.SetTooltip("Import macro links from clipboard");
-        }
-
-        ImGui.Columns(1);
     }
 
     private string tempConstantName = string.Empty;
@@ -731,5 +832,16 @@ public class SettingsWindow : Window
 
             ImGui.EndCombo();
         }
+    }
+
+    private static bool IconButtonEnabledWhen(bool enabled, FontAwesomeIcon icon, string id)
+    {
+        if (!enabled)
+            ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f);
+        var result = ImGuiComponents.IconButton(id, icon);
+        if (!enabled)
+            ImGui.PopStyleVar();
+
+        return result && enabled;
     }
 }

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -45,11 +45,17 @@ public class SettingsWindow : Window
     private string matchSigilFuzzy;
     private string matchSigilFuzzyParts;
 
-    public SettingsWindow(FindAnythingPlugin plugin) : base("Wotsit Settings", ImGuiWindowFlags.NoResize)
+    private const int SaveDiscardOffset = -40;
+
+    public SettingsWindow(FindAnythingPlugin plugin) : base("Wotsit Settings")
     {
-        this.SizeCondition = ImGuiCond.Always;
-        this.Size = new Vector2(850, 660) * ImGuiHelpers.GlobalScale;
         this.plugin = plugin;
+
+        this.SizeConstraints = new WindowSizeConstraints
+        {
+            MinimumSize = new Vector2(860, 660),
+            MaximumSize = new Vector2(10000, 10000),
+        };
     }
 
     public override void OnOpen()
@@ -88,200 +94,244 @@ public class SettingsWindow : Window
 
     public override void Draw()
     {
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "What to search");
-        for (var i = 0; i < this.order.Count; i++) {
-            var search = this.order[i];
+        if (ImGui.BeginTabBar("##find-anything-tabs")) {
+            if (ImGui.BeginTabItem("General")) {
+                ImGui.BeginChild("ScrollingOthers", ImGuiHelpers.ScaledVector2(0, SaveDiscardOffset), true,
+                    ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
 
-            var name = search switch {
-                Configuration.SearchSetting.Duty => "Duties",
-                Configuration.SearchSetting.Aetheryte => "Aetherytes",
-                Configuration.SearchSetting.MainCommand => "Commands",
-                Configuration.SearchSetting.GeneralAction => "General Actions",
-                Configuration.SearchSetting.Emote => "Emotes",
-                Configuration.SearchSetting.PluginSettings => "other plugins",
-                Configuration.SearchSetting.Gearsets => "Gear Sets",
-                Configuration.SearchSetting.CraftingRecipes => "Crafting Recipes",
-                Configuration.SearchSetting.GatheringItems => "Gathering Items",
-                Configuration.SearchSetting.Mounts => "Mounts",
-                Configuration.SearchSetting.Minions => "Minions",
-                Configuration.SearchSetting.MacroLinks => "Macro Links",
-                Configuration.SearchSetting.Internal => "Wotsit",
-                _ => null,
-            };
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "How to open");
 
-            if (name == null) {
-                continue;
-            }
-
-            var isRequired = search is Configuration.SearchSetting.Internal or Configuration.SearchSetting.MacroLinks;
-
-            ImGui.PushFont(UiBuilder.IconFont);
-
-            if (ImGui.Button($"{FontAwesomeIcon.ArrowUp.ToIconString()}##{search}") && i != 0) {
-                (this.order[i], this.order[i - 1]) = (this.order[i - 1], this.order[i]);
-            }
-
-            ImGui.SameLine();
-
-            if (ImGui.Button($"{FontAwesomeIcon.ArrowDown.ToIconString()}##{search}") && i != this.order.Count - 1) {
-                (this.order[i], this.order[i + 1]) = (this.order[i + 1], this.order[i]);
-            }
-
-            ImGui.PopFont();
-
-            ImGui.SameLine();
-
-            if (isRequired) {
-                ImGui.TextUnformatted($"Search in {name}");
-            } else {
-                ImGui.CheckboxFlags($"Search in {name}", ref this.flags, (uint) search);
-            }
-        }
-
-        ImGui.CheckboxFlags("Mathematical Expressions", ref this.flags, (uint) Configuration.SearchSetting.Maths);
-
-        ImGuiHelpers.ScaledDummy(15);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(15);
-
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "How to open");
-
-        if (ImGui.RadioButton("Keyboard Combo", openMode == Configuration.OpenMode.Combo))
-        {
-            openMode = Configuration.OpenMode.Combo;
-        }
-        if (ImGui.RadioButton("Key Double Tap", openMode == Configuration.OpenMode.ShiftShift))
-        {
-            openMode = Configuration.OpenMode.ShiftShift;
-        }
-
-        ImGuiHelpers.ScaledDummy(10);
-
-        switch (openMode)
-        {
-            case Configuration.OpenMode.ShiftShift:
-                VirtualKeySelect("Key to double tap", ref shiftShiftKey);
-
-                if (ImGui.InputInt("Delay (ms)", ref shiftShiftDelay))
-                {
-                    shiftShiftDelay = Math.Max(shiftShiftDelay, 0);
+                if (ImGui.RadioButton("Keyboard Combo", openMode == Configuration.OpenMode.Combo)) {
+                    openMode = Configuration.OpenMode.Combo;
                 }
-                break;
-            case Configuration.OpenMode.Combo:
-                VirtualKeySelect("Combo Modifier 1", ref comboModifierKey);
-                VirtualKeySelect("Combo Modifier 2", ref comboModifier2Key);
-                VirtualKeySelect("Combo Key", ref comboKey);
 
-                ImGuiHelpers.ScaledDummy(2);
-                VirtualKeySelect("Wiki Modifier(go directly to wiki mode)", ref wikiComboKey);
-                ImGuiHelpers.ScaledDummy(2);
-
-                ImGui.Checkbox("Prevent passthrough to game", ref preventPassthrough);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
-
-        ImGuiHelpers.ScaledDummy(5);
-
-        VirtualKeySelect("Quick Select Key", ref quickSelectKey);
-        
-        ImGuiHelpers.ScaledDummy(15);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(15);
-        
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "Search Mode");
-        ImGui.TextWrapped("Use this menu to select the default search mode.\n" +
-                          "- \"Simple\" looks for the exact text entered.\n" +
-                          "- \"Fuzzy\" finds close matches to your text even if some characters are missing (e.g. \"dufi\" can locate the Duty Finder).\n" +
-                          "- \"FuzzyParts\" is like Fuzzy but each word in the input is searched for separately, so that input word order does not matter.");
-        
-        if (ImGui.BeginCombo("Search mode", this.matchMode.ToString()))
-        {
-            foreach (var key in Enum.GetValues<MatchMode>())
-            {
-                if (ImGui.Selectable(key.ToString(), key == this.matchMode))
-                {
-                    this.matchMode = key;
+                if (ImGui.RadioButton("Key Double Tap", openMode == Configuration.OpenMode.ShiftShift)) {
+                    openMode = Configuration.OpenMode.ShiftShift;
                 }
+
+                ImGuiHelpers.ScaledDummy(10);
+
+                switch (openMode) {
+                    case Configuration.OpenMode.ShiftShift:
+                        VirtualKeySelect("Key to double tap", ref shiftShiftKey);
+
+                        if (ImGui.InputInt("Delay (ms)", ref shiftShiftDelay)) {
+                            shiftShiftDelay = Math.Max(shiftShiftDelay, 0);
+                        }
+
+                        break;
+                    case Configuration.OpenMode.Combo:
+                        VirtualKeySelect("Combo Modifier 1", ref comboModifierKey);
+                        VirtualKeySelect("Combo Modifier 2", ref comboModifier2Key);
+                        VirtualKeySelect("Combo Key", ref comboKey);
+
+                        ImGuiHelpers.ScaledDummy(2);
+                        VirtualKeySelect("Wiki Modifier(go directly to wiki mode)", ref wikiComboKey);
+                        ImGuiHelpers.ScaledDummy(2);
+
+                        ImGui.Checkbox("Prevent passthrough to game", ref preventPassthrough);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                ImGuiHelpers.ScaledDummy(5);
+
+                VirtualKeySelect("Quick Select Key", ref quickSelectKey);
+
+                ImGuiHelpers.ScaledDummy(15);
+                ImGui.Separator();
+                ImGuiHelpers.ScaledDummy(15);
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Search mode");
+                ImGui.TextWrapped("Use this menu to select the default search mode:\n" +
+                                  "  - \"Simple\" looks for the exact text entered.\n" +
+                                  "  - \"Fuzzy\" finds close matches to your text even if some characters are missing (e.g. \"dufi\" can locate the Duty Finder).\n" +
+                                  "  - \"FuzzyParts\" is like Fuzzy but each word in the input is searched for separately, so that input word order does not matter.");
+                ImGui.TextWrapped(
+                    "When using fuzzy search modes, results are shown in order from best match to worst match.");
+
+                if (ImGui.BeginCombo("Search mode", this.matchMode.ToString())) {
+                    foreach (var key in Enum.GetValues<MatchMode>()) {
+                        if (ImGui.Selectable(key.ToString(), key == this.matchMode)) {
+                            this.matchMode = key;
+                        }
+                    }
+
+                    ImGui.EndCombo();
+                }
+
+                ImGuiHelpers.ScaledDummy(5);
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Search prefixes");
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    "Inputting one of the prefixes below as the first character of your search text " +
+                    "will temporarily change the search mode for that search.");
+
+                ImGui.PushItemWidth(40);
+                ImGui.InputText("Simple search mode prefix", ref this.matchSigilSimple, 1);
+                ImGui.InputText("Fuzzy search mode prefix", ref this.matchSigilFuzzy, 1);
+                ImGui.InputText("FuzzyParts search mode prefix", ref this.matchSigilFuzzyParts, 1);
+                ImGui.PopItemWidth();
+
+                ImGuiHelpers.ScaledDummy(15);
+                ImGui.Separator();
+                ImGuiHelpers.ScaledDummy(15);
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Math constants");
+                ImGui.TextWrapped(
+                    "Use this menu to tie constants to values, to be used in expressions.\nAdd a constant again to edit it.");
+
+                DrawConstantsSection();
+
+                ImGuiHelpers.ScaledDummy(15);
+                ImGui.Separator();
+                ImGuiHelpers.ScaledDummy(15);
+
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Other stuff");
+
+                ImGui.Checkbox("Enable Search History", ref this.historyEnabled);
+                ImGui.Checkbox("Show Gil cost in Aetheryte results", ref this.aetheryteGilCost);
+                ImGui.Checkbox("Show \"Market Board\" shortcut to teleport to the closest market board city",
+                    ref this.marketBoardShortcut);
+                ImGui.Checkbox("Show \"Striking Dummy\" shortcut to teleport to the closest striking dummy location",
+                    ref this.strikingDummyShortcut);
+
+                if (ImGui.BeginCombo("Emote Motion-Only?", this.emoteMotionMode.ToString())) {
+                    foreach (var key in Enum.GetValues<Configuration.EmoteMotionMode>()) {
+                        if (ImGui.Selectable(key.ToString(), key == this.emoteMotionMode)) {
+                            this.emoteMotionMode = key;
+                        }
+                    }
+
+                    ImGui.EndCombo();
+                }
+
+                ImGui.Checkbox("Show Emote command in search result", ref this.showEmoteCommand);
+                ImGui.Checkbox("Try to prevent spoilers in wiki mode(not 100% reliable)", ref this.wikiModeNoSpoilers);
+                ImGui.Checkbox("Directly go to wiki mode when opening search", ref this.onlyWiki);
+                ImGui.SliderFloat2("Search window position offset", ref this.posOffset, -800, 800);
+                if (ImGui.BeginCombo("Scroll Speed", this.speed.ToString())) {
+                    foreach (var key in Enum.GetValues<Configuration.ScrollSpeed>()) {
+                        if (ImGui.Selectable(key.ToString(), key == this.speed)) {
+                            this.speed = key;
+                        }
+                    }
+
+                    ImGui.EndCombo();
+                }
+
+                ImGui.Checkbox("Don't open Wotsit in combat", ref this.notInCombat);
+                ImGui.Checkbox("Force TeamCraft links to open in your browser", ref this.tcForceBrowser);
+
+                ImGuiHelpers.ScaledDummy(5);
+
+                // End scrollable container
+                ImGui.EndChild();
+                ImGui.EndTabItem();
             }
 
-            ImGui.EndCombo();
-        }
-        
-        ImGuiHelpers.ScaledDummy(5);
-        ImGui.PushItemWidth(40);
-        ImGui.InputText("Simple search mode prefix", ref this.matchSigilSimple, 1);
-        ImGui.InputText("Fuzzy search mode prefix", ref this.matchSigilFuzzy, 1);
-        ImGui.InputText("FuzzyParts search mode prefix", ref this.matchSigilFuzzyParts, 1);
-        ImGui.PopItemWidth();
+            if (ImGui.BeginTabItem("What to search")) {
+                ImGui.BeginChild("ScrollingMain", ImGuiHelpers.ScaledVector2(0, SaveDiscardOffset), true,
+                    ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "What to search");
 
-        ImGuiHelpers.ScaledDummy(15);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(15);
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(
+                    "When using the default \"Simple\" search mode, results will appear in the order defined " +
+                    "below.\n\n" +
+                    "For fuzzy search modes, results appear in 'best match' to 'worst match' order, and " +
+                    "the order defined below will be used only for tie-breaks (when multiple results match " +
+                    "equally well).\n\n" +
+                    "Un-ticking a check box will cause all entries from that category to be ignored in any mode.");
 
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "Macro Links");
-        ImGui.TextWrapped("Use this menu to tie search results to macros.\nClick \"Add Macro\", enter the text you want to access it under, select whether or not it is a shared macro and enter its ID.\nUse the ';' character to add search text for a macro, only the first part text will be shown, e.g. \"SGE;sage;healer\".");
 
-        DrawMacrosSection();
+                for (var i = 0; i < this.order.Count; i++) {
+                    var search = this.order[i];
 
-        ImGuiHelpers.ScaledDummy(15);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(15);
+                    var name = search switch
+                    {
+                        Configuration.SearchSetting.Duty => "Duties",
+                        Configuration.SearchSetting.Aetheryte => "Aetherytes",
+                        Configuration.SearchSetting.MainCommand => "Commands",
+                        Configuration.SearchSetting.GeneralAction => "General Actions",
+                        Configuration.SearchSetting.Emote => "Emotes",
+                        Configuration.SearchSetting.PluginSettings => "other plugins",
+                        Configuration.SearchSetting.Gearsets => "Gear Sets",
+                        Configuration.SearchSetting.CraftingRecipes => "Crafting Recipes",
+                        Configuration.SearchSetting.GatheringItems => "Gathering Items",
+                        Configuration.SearchSetting.Mounts => "Mounts",
+                        Configuration.SearchSetting.Minions => "Minions",
+                        Configuration.SearchSetting.MacroLinks => "Macro Links",
+                        Configuration.SearchSetting.Internal => "Wotsit",
+                        _ => null,
+                    };
 
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "Math Constants");
-        ImGui.TextWrapped("Use this menu to tie constants to values, to be used in expressions.\nAdd a constant again to edit it.");
+                    if (name == null) {
+                        continue;
+                    }
 
-        DrawConstantsSection();
+                    var isRequired =
+                        search is Configuration.SearchSetting.Internal or Configuration.SearchSetting.MacroLinks;
 
-        ImGuiHelpers.ScaledDummy(15);
-        ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(15);
+                    ImGui.PushFont(UiBuilder.IconFont);
 
-        ImGui.TextColored(ImGuiColors.DalamudGrey, "Other stuff");
+                    if (ImGui.Button($"{FontAwesomeIcon.ArrowUp.ToIconString()}##{search}") && i != 0) {
+                        (this.order[i], this.order[i - 1]) = (this.order[i - 1], this.order[i]);
+                    }
 
-        ImGui.Checkbox("Enable Search History", ref this.historyEnabled);
-        ImGui.Checkbox("Show Gil cost in Aetheryte results", ref this.aetheryteGilCost);
-        ImGui.Checkbox("Show \"Market Board\" shortcut to teleport to the closest market board city", ref this.marketBoardShortcut);
-        ImGui.Checkbox("Show \"Striking Dummy\" shortcut to teleport to the closest striking dummy location", ref this.strikingDummyShortcut);
+                    ImGui.SameLine();
 
-        if (ImGui.BeginCombo("Emote Motion-Only?", this.emoteMotionMode.ToString()))
-        {
-            foreach (var key in Enum.GetValues<Configuration.EmoteMotionMode>())
-            {
-                if (ImGui.Selectable(key.ToString(), key == this.emoteMotionMode))
-                {
-                    this.emoteMotionMode = key;
+                    if (ImGui.Button($"{FontAwesomeIcon.ArrowDown.ToIconString()}##{search}") &&
+                        i != this.order.Count - 1) {
+                        (this.order[i], this.order[i + 1]) = (this.order[i + 1], this.order[i]);
+                    }
+
+                    ImGui.PopFont();
+
+                    ImGui.SameLine();
+
+                    if (isRequired) {
+                        ImGui.TextUnformatted($"Search in {name}");
+                    }
+                    else {
+                        ImGui.CheckboxFlags($"Search in {name}", ref this.flags, (uint)search);
+                    }
                 }
+
+                ImGui.CheckboxFlags("Mathematical Expressions", ref this.flags,
+                    (uint)Configuration.SearchSetting.Maths);
+
+                ImGui.EndChild();
+                ImGui.EndTabItem();
             }
 
-            ImGui.EndCombo();
-        }
+            if (ImGui.BeginTabItem("Macro links")) {
+                ImGui.BeginChild("ScrollingMain", ImGuiHelpers.ScaledVector2(0, SaveDiscardOffset), true,
+                    ImGuiWindowFlags.HorizontalScrollbar | ImGuiWindowFlags.NoBackground);
 
-        ImGui.Checkbox("Show Emote command in search result", ref this.showEmoteCommand);
-        ImGui.Checkbox("Try to prevent spoilers in wiki mode(not 100% reliable)", ref this.wikiModeNoSpoilers);
-        ImGui.Checkbox("Directly go to wiki mode when opening search", ref this.onlyWiki);
-        ImGui.SliderFloat2("Search window position offset", ref this.posOffset, -800, 800);
-        if (ImGui.BeginCombo("Scroll Speed", this.speed.ToString()))
-        {
-            foreach (var key in Enum.GetValues<Configuration.ScrollSpeed>())
-            {
-                if (ImGui.Selectable(key.ToString(), key == this.speed))
-                {
-                    this.speed = key;
-                }
+                ImGui.TextColored(ImGuiColors.DalamudGrey, "Macro links");
+                ImGui.TextWrapped(
+                    "Use this menu to tie search results to macros.\nClick \"Add Macro\", enter the text you want to access it under, select whether or not it is a shared macro and enter its ID.\nUse the ';' character to add search text for a macro, only the first part text will be shown, e.g. \"SGE;sage;healer\".");
+
+                DrawMacrosSection();
+
+                ImGui.EndChild();
+                ImGui.EndTabItem();
             }
 
-            ImGui.EndCombo();
+
+            ImGui.EndTabBar();
         }
-        ImGui.Checkbox("Don't open Wotsit in combat", ref this.notInCombat);
-        ImGui.Checkbox("Force TeamCraft links to open in your browser", ref this.tcForceBrowser);
 
-        ImGuiHelpers.ScaledDummy(5);
         ImGui.Separator();
-        ImGuiHelpers.ScaledDummy(5);
+        ImGuiHelpers.ScaledDummy(2);
 
-        if (ImGui.Button("Save"))
+        var save = ImGui.Button("Save");
+        ImGui.SameLine();
+        var saveAndClose = ImGui.Button("Save and Close");
+
+        if (save || saveAndClose)
         {
             FindAnythingPlugin.Configuration.ToSearchV3 = (Configuration.SearchSetting) this.flags;
             FindAnythingPlugin.Configuration.Order = this.order;
@@ -320,7 +370,8 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.Save();
 
             FindAnythingPlugin.TexCache.ReloadMacroIcons();
-            IsOpen = false;
+            if (saveAndClose)
+                IsOpen = false;
         }
 
         ImGui.SameLine();


### PR DESCRIPTION
Re-organize settings
- Split settings into 3 tabs ("General", 'What to search", "Macro links") since settings were getting quite long, especially for users with many macro links.
- Replace the "Save" button with two buttons: "Save", and "Save and Close". This allows for saving settings without closing the settings window.
- Ensure the above buttons are always visible, and not part of the scrollable area. This allows for saving or discarding settings changes without having to scroll down.

Changes to macro link configuration
- Add "rearrange mode" for macro links which allows manually rearranging them via buttons or via drag & drop.
  - Should be enough to close #46.
- Allow changing macro link search order.  Previously the order was always bottom to top (or forwards through the list, as the list elements are shown in index-descending order in the UI), but now also top to bottom (or backwards through the list) is also possible.
  - Whether the default behavior is intuitive or not probably depends on the person (see above issue), but "fixing" this would result in the displayed order reversing for those who already have many macros saved. So I decided to make it an option, and also give a "reverse all" button in the arrange mode so people can easily fix this to behave however they like.

Changes to "what to search"
- Add configurable category-based weights for use in fuzzy search modes. The default weight is 100 and it works by simply multiplying all match scores in a given category by that category's weight.
  - For the numerous people who had issues with aetherytes appearing after crafting recipes and so on, this allows them to re-balance matching scores to their liking.
- Add help tooltips explaining how search order and weight are used.
  - A number of people who switched to fuzzy matching seemed confused about how this worked. There is now a detailed tooltip for "search order" which explains this. Closes #55.
- Add a static check box for categories which can't be disabled so they line up better visually.

Changes to double-tap (shift shift) open modes
- Rename default "key double tap" delay unit from "ms" to "frames", since it's actually based on frames.
- Add a new "key double tap" unit "milliseconds" which actually works based on milliseconds.
  - The issue addressed by these two changes is arguably a bug, but probably not fixable just by migrating settings. The reason being that even if we fixed it by multiplying the "frames" setting by 16.67 for example, it may feel different for users who typically run at a different frame rate. This does make "frames" the default setting when key double tap is selected, which is maybe not ideal, but anyway users can now switch to actual millisecond-based timing if they prefer it.
- Fixed some edge case behavior with double tap which should make it more consistent.

Other
- Show an outline overlay at the search window location for 3 seconds after changing the position offset in the settings.
  - Should be good enough to close #19.
- Add a help tooltip explaining what search mode prefixes are in more detail.
- Visually disable move up/down buttons for rows which can't be moved further up/down.