### PR TITLE
Scaling improvements and some minor features

### DIFF
--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -49,6 +49,7 @@ namespace Dalamud.FindAnything
 
         public bool WikiModeNoSpoilers { get; set; } = true;
         public bool TeamCraftForceBrowser { get; set; } = false;
+        public bool DisableMouseSelection { get; set; } = false;
 
         public enum OpenMode
         {

--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -50,6 +50,7 @@ namespace Dalamud.FindAnything
         public bool WikiModeNoSpoilers { get; set; } = true;
         public bool TeamCraftForceBrowser { get; set; } = false;
         public bool DisableMouseSelection { get; set; } = false;
+        public bool OpenCraftingLogToRecipe { get; set; } = false;
 
         public enum OpenMode
         {

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -2545,12 +2545,23 @@ namespace Dalamud.FindAnything
                     for (var i = 0; i < results.Length; i++)
                     {
                         var result = results[i];
-                        if (ImGui.Selectable($"{result.Name}###faEntry{i}", i == selectedIndex, ImGuiSelectableFlags.None,
+                        var selectableFlags = ImGuiSelectableFlags.None;
+
+                        var disableMouse = Configuration.DisableMouseSelection && !isQuickSelect;
+                        if (disableMouse) {
+                            selectableFlags = ImGuiSelectableFlags.Disabled;
+                            ImGui.PushStyleVar(ImGuiStyleVar.DisabledAlpha, 1f);
+                        }
+
+                        if (ImGui.Selectable($"{result.Name}###faEntry{i}", i == selectedIndex, selectableFlags,
                                 new Vector2(childSize.X, textSize.Y)))
                         {
                             Log.Information("Selectable click");
                             clickedIndex = i;
                         }
+
+                        if (disableMouse)
+                            ImGui.PopStyleVar();
 
                         var thisTextSize = ImGui.CalcTextSize(result.Name);
 

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -2370,6 +2370,8 @@ namespace Dalamud.FindAnything
 
             var scaledFour = 4 * ImGuiHelpers.GlobalScale;
             var iconSize = textSize with { X = textSize.Y };
+            var scrollbarWidth = ImGui.GetStyle().ScrollbarSize + 2;
+            var windowPadding = ImGui.GetStyle().WindowPadding.X * 2;
 
             if (results is { Length: > 0 })
             {
@@ -2384,7 +2386,7 @@ namespace Dalamud.FindAnything
 
             ImGui.Begin("###findeverything", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
 
-            ImGui.PushItemWidth(size.X - (45 * ImGuiHelpers.GlobalScale));
+            ImGui.PushItemWidth(size.X - iconSize.Y - windowPadding - ImGui.GetStyle().FramePadding.X - ImGui.GetStyle().ItemSpacing.X);
 
             var searchHint = searchState.ActualSearchMode switch
             {
@@ -2588,13 +2590,13 @@ namespace Dalamud.FindAnything
 
                         if (i < 9 && Configuration.QuickSelectKey != VirtualKey.NO_KEY)
                         {
-                            ImGui.SameLine(size.X - (65 * ImGuiHelpers.GlobalScale));
+                            ImGui.SameLine(size.X - iconSize.X * 1.75f - scrollbarWidth - windowPadding);
                             ImGui.TextColored(ImGuiColors.DalamudGrey, (i + 1).ToString());
                         }
 
                         if (result.Icon != null)
                         {
-                            ImGui.SameLine(size.X - (50 * ImGuiHelpers.GlobalScale));
+                            ImGui.SameLine(size.X - iconSize.X - scrollbarWidth - windowPadding);
                             ImGui.Image(result.Icon.ImGuiHandle, iconSize);
                         }
                     }

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1193,9 +1193,14 @@ namespace Dalamud.FindAnything
             public CraftType? CraftType { get; set; }
 
             public void Selected() {
-                var id = this.Recipe.ItemResult.Value?.RowId ?? 0;
-                if (id > 0) {
-                    GameStateCache.SearchForItemByCraftingMethod((ushort) (id % 500_000));
+                if (Configuration.OpenCraftingLogToRecipe) {
+                    GameStateCache.OpenRecipe(this.Recipe.RowId);
+                }
+                else {
+                    var id = this.Recipe.ItemResult.Value?.RowId ?? 0;
+                    if (id > 0) {
+                        GameStateCache.SearchForItemByCraftingMethod(id % 500_000);
+                    }
                 }
             }
 

--- a/Dalamud.FindAnything/GameStateCache.cs
+++ b/Dalamud.FindAnything/GameStateCache.cs
@@ -26,7 +26,8 @@ public unsafe class GameStateCache
     
     internal bool IsMinionUnlocked(uint minionId) => UIState.Instance()->IsCompanionUnlocked(minionId);
 
-    internal void SearchForItemByCraftingMethod(ushort itemId) => AgentRecipeNote.Instance()->OpenRecipeByItemId(itemId);
+    internal void OpenRecipe(uint recipeId) => AgentRecipeNote.Instance()->OpenRecipeByRecipeId(recipeId);
+    internal void SearchForItemByCraftingMethod(uint itemId) => AgentRecipeNote.Instance()->OpenRecipeByItemId(itemId);
 
     internal void SearchForItemByGatheringMethod(ushort itemId) => AgentGatheringNote.Instance()->OpenGatherableByItemId(itemId);
 

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -47,6 +47,7 @@ public class SettingsWindow : Window
     private bool tcForceBrowser;
     private bool historyEnabled;
     private bool disableMouseSelection;
+    private bool openCraftingLogToRecipe;
     private MatchMode matchMode;
     private string matchSigilSimple;
     private string matchSigilFuzzy;
@@ -98,6 +99,7 @@ public class SettingsWindow : Window
         this.tcForceBrowser = FindAnythingPlugin.Configuration.TeamCraftForceBrowser;
         this.historyEnabled = FindAnythingPlugin.Configuration.HistoryEnabled;
         this.disableMouseSelection = FindAnythingPlugin.Configuration.DisableMouseSelection;
+        this.openCraftingLogToRecipe = FindAnythingPlugin.Configuration.OpenCraftingLogToRecipe;
         this.matchMode = FindAnythingPlugin.Configuration.MatchMode;
         this.matchSigilSimple = FindAnythingPlugin.Configuration.MatchSigilSimple;
         this.matchSigilFuzzy = FindAnythingPlugin.Configuration.MatchSigilFuzzy;
@@ -257,6 +259,7 @@ public class SettingsWindow : Window
                 ImGui.Checkbox("Don't open Wotsit in combat", ref this.notInCombat);
                 ImGui.Checkbox("Force TeamCraft links to open in your browser", ref this.tcForceBrowser);
                 ImGui.Checkbox("Disable mouse selection in results list unless Quick Select Key is held", ref this.disableMouseSelection);
+                ImGui.Checkbox("When selecting a crafting recipe, jump to the recipe instead of using Recipe Search", ref this.openCraftingLogToRecipe);
 
                 ImGuiHelpers.ScaledDummy(5);
 
@@ -461,6 +464,7 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.TeamCraftForceBrowser = this.tcForceBrowser;
             FindAnythingPlugin.Configuration.HistoryEnabled = this.historyEnabled;
             FindAnythingPlugin.Configuration.DisableMouseSelection = this.disableMouseSelection;
+            FindAnythingPlugin.Configuration.OpenCraftingLogToRecipe = this.openCraftingLogToRecipe;
 
             FindAnythingPlugin.Configuration.MatchMode = this.matchMode;
             FindAnythingPlugin.Configuration.MatchSigilSimple = this.matchSigilSimple;

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -46,6 +46,7 @@ public class SettingsWindow : Window
     private bool notInCombat;
     private bool tcForceBrowser;
     private bool historyEnabled;
+    private bool disableMouseSelection;
     private MatchMode matchMode;
     private string matchSigilSimple;
     private string matchSigilFuzzy;
@@ -96,6 +97,7 @@ public class SettingsWindow : Window
         this.notInCombat = FindAnythingPlugin.Configuration.NotInCombat;
         this.tcForceBrowser = FindAnythingPlugin.Configuration.TeamCraftForceBrowser;
         this.historyEnabled = FindAnythingPlugin.Configuration.HistoryEnabled;
+        this.disableMouseSelection = FindAnythingPlugin.Configuration.DisableMouseSelection;
         this.matchMode = FindAnythingPlugin.Configuration.MatchMode;
         this.matchSigilSimple = FindAnythingPlugin.Configuration.MatchSigilSimple;
         this.matchSigilFuzzy = FindAnythingPlugin.Configuration.MatchSigilFuzzy;
@@ -254,6 +256,7 @@ public class SettingsWindow : Window
 
                 ImGui.Checkbox("Don't open Wotsit in combat", ref this.notInCombat);
                 ImGui.Checkbox("Force TeamCraft links to open in your browser", ref this.tcForceBrowser);
+                ImGui.Checkbox("Disable mouse selection in results list unless Quick Select Key is held", ref this.disableMouseSelection);
 
                 ImGuiHelpers.ScaledDummy(5);
 
@@ -457,7 +460,8 @@ public class SettingsWindow : Window
             FindAnythingPlugin.Configuration.NotInCombat = this.notInCombat;
             FindAnythingPlugin.Configuration.TeamCraftForceBrowser = this.tcForceBrowser;
             FindAnythingPlugin.Configuration.HistoryEnabled = this.historyEnabled;
-            
+            FindAnythingPlugin.Configuration.DisableMouseSelection = this.disableMouseSelection;
+
             FindAnythingPlugin.Configuration.MatchMode = this.matchMode;
             FindAnythingPlugin.Configuration.MatchSigilSimple = this.matchSigilSimple;
             FindAnythingPlugin.Configuration.MatchSigilFuzzy = this.matchSigilFuzzy;


### PR DESCRIPTION
- Improves scrolling and scaling at different font sizes and global scales. Previously, and especially at unusual scale factors, some elements were spaced or sized slightly inconsistently, and the scroll offset could become out-of-sync, resulting in the selected element's position on screen "drifting" when scrolling through a long list with the keyboard.
- Adds a feature to disable mouse selection unless the quick select key is held. For people who typically don't use the mouse with Wotsit, this can help reduce "phantom hovering", which in some cases could cause confusion about which element is actually highlighted when the mouse happens to be at rest over the selection list. With this feature enabled, only the keyboard is capable of highlighting and selecting elements (unless the quick select key is held).
- Adds a feature to open crafting recipes directly to the selected recipe variant, rather than opening the recipe search list. Some users mentioned that they would prefer this.

Submitting this as a single PR for simplicity but please let me know if you'd prefer it broken down per feature, or if there's anything else you'd like me to change. Thanks!