### PR TITLE
Add support for searching Fashion Accessories and Collections

### DIFF
--- a/Dalamud.FindAnything/Configuration.cs
+++ b/Dalamud.FindAnything/Configuration.cs
@@ -15,15 +15,13 @@ namespace Dalamud.FindAnything
 
         public SearchSetting ToSearchV3 { get; set; } =
             SearchSetting.Aetheryte | SearchSetting.Duty | SearchSetting.MainCommand | SearchSetting.GeneralAction |
-            SearchSetting.Emote | SearchSetting.PluginSettings
-            | SearchSetting.Gearsets | SearchSetting.CraftingRecipes | SearchSetting.GatheringItems | SearchSetting.Mounts |
-            SearchSetting.Minions | SearchSetting.MacroLinks | SearchSetting.Internal | SearchSetting.Maths |
-            SearchSetting.Reserved8
-            | SearchSetting.Reserved9 | SearchSetting.Reserved10 | SearchSetting.Reserved11 | SearchSetting.Reserved12 |
-            SearchSetting.Reserved13 | SearchSetting.Reserved14 | SearchSetting.Reserved15 | SearchSetting.Reserved16
-            | SearchSetting.Reserved17 | SearchSetting.Reserved18 | SearchSetting.Reserved19 |
-            SearchSetting.Reserved20 | SearchSetting.Reserved21 | SearchSetting.Reserved22 | SearchSetting.Reserved23 |
-            SearchSetting.Reserved24;
+            SearchSetting.Emote | SearchSetting.PluginSettings | SearchSetting.Gearsets | SearchSetting.CraftingRecipes |
+            SearchSetting.GatheringItems | SearchSetting.Mounts | SearchSetting.Minions | SearchSetting.MacroLinks |
+            SearchSetting.Internal | SearchSetting.Maths | SearchSetting.FashionAccessories | SearchSetting.Collection |
+            SearchSetting.Reserved10 | SearchSetting.Reserved11 | SearchSetting.Reserved12 | SearchSetting.Reserved13 |
+            SearchSetting.Reserved14 | SearchSetting.Reserved15 | SearchSetting.Reserved16 | SearchSetting.Reserved17 |
+            SearchSetting.Reserved18 | SearchSetting.Reserved19 | SearchSetting.Reserved20 | SearchSetting.Reserved21 |
+            SearchSetting.Reserved22 | SearchSetting.Reserved23 | SearchSetting.Reserved24;
 
         public Dictionary<SearchSetting, int> SearchWeights = new();
 
@@ -74,8 +72,8 @@ namespace Dalamud.FindAnything
             MacroLinks = 1 << 11, // Cannot be toggled off
             Internal = 1 << 12, // Cannot be toggled off
             Maths = 1 << 13,
-            Reserved8 = 1 << 14,
-            Reserved9 = 1 << 15,
+            FashionAccessories = 1 << 14,
+            Collection = 1 << 15,
             Reserved10 = 1 << 16,
             Reserved11 = 1 << 17,
             Reserved12 = 1 << 18,
@@ -196,6 +194,8 @@ namespace Dalamud.FindAnything
             SearchSetting.PluginSettings,
             SearchSetting.Emote,
             SearchSetting.Internal,
+            SearchSetting.Collection,
+            SearchSetting.FashionAccessories,
             SearchSetting.CraftingRecipes,
             SearchSetting.GatheringItems,
         };

--- a/Dalamud.FindAnything/GameStateCache.cs
+++ b/Dalamud.FindAnything/GameStateCache.cs
@@ -22,6 +22,8 @@ public unsafe class GameStateCache
     public IReadOnlyList<uint> UnlockedEmoteKeys { get; private set; }
     public IReadOnlyList<uint> UnlockedMountKeys { get; private set; }
     public IReadOnlyList<uint> UnlockedMinionKeys { get; private set; }
+    public IReadOnlyList<uint> UnlockedCollectionKeys { get; set; }
+    public IReadOnlyList<uint> UnlockedFashionAccessoryKeys { get; set; }
     public IReadOnlyList<Gearset> Gearsets { get; private set; }
     
     internal bool IsMinionUnlocked(uint minionId) => UIState.Instance()->IsCompanionUnlocked(minionId);
@@ -53,6 +55,10 @@ public unsafe class GameStateCache
         UnlockedMountKeys = FindAnythingPlugin.Data.GetExcelSheet<Mount>()!.Where(x => PlayerState.Instance()->IsMountUnlocked(x.RowId)).Select(x => x.RowId).ToList();
 
         UnlockedMinionKeys = FindAnythingPlugin.Data.GetExcelSheet<Companion>()!.Where(x => IsMinionUnlocked(x.RowId)).Select(x => x.RowId).ToList();
+
+        UnlockedFashionAccessoryKeys = FindAnythingPlugin.Data.GetExcelSheet<Ornament>()!.Where(x => PlayerState.Instance()->IsOrnamentUnlocked(x.RowId)).Select(x => x.RowId).ToList();
+
+        UnlockedCollectionKeys = FindAnythingPlugin.Data.GetExcelSheet<McGuffin>()!.Where(x => PlayerState.Instance()->IsMcGuffinUnlocked(x.RowId)).Select(x => x.RowId).ToList();
         
         var gsEntries = (RaptureGearsetModule.GearsetEntry*)RaptureGearsetModule.Instance()->Entries;
         var gearsets = new List<Gearset>();

--- a/Dalamud.FindAnything/Interop.cs
+++ b/Dalamud.FindAnything/Interop.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Dalamud.Utility.Signatures;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+namespace Dalamud.FindAnything;
+
+public class Interop
+{
+    private static Interop? instance = null;
+    public static Interop Instance => instance ??= new Interop();
+
+    private delegate byte UseMcGuffinDelegate(IntPtr module, uint id);
+
+    [Signature("E8 ?? ?? ?? ?? EB 0C 48 8B 07")]
+    private readonly UseMcGuffinDelegate? useMcGuffin = null!;
+
+    public Interop()
+    {
+        FindAnythingPlugin.GameInteropProvider.InitializeFromAttributes(this);
+    }
+
+    public unsafe void UseMgGuffin(uint mcGuffinId)
+    {
+        if (useMcGuffin == null) {
+            throw new InvalidOperationException("Could not find signature for using collection item");
+        }
+
+        var module = (IntPtr)Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.McGuffin);
+        useMcGuffin(module, mcGuffinId);
+    }
+}

--- a/Dalamud.FindAnything/SettingsWindow.cs
+++ b/Dalamud.FindAnything/SettingsWindow.cs
@@ -316,6 +316,8 @@ public class SettingsWindow : Window
                         Configuration.SearchSetting.Minions => "Minions",
                         Configuration.SearchSetting.MacroLinks => "Macro Links",
                         Configuration.SearchSetting.Internal => "Wotsit",
+                        Configuration.SearchSetting.FashionAccessories => "Fashion Accessories",
+                        Configuration.SearchSetting.Collection => "Collection",
                         _ => null,
                     };
 

--- a/Dalamud.FindAnything/TextureCache.cs
+++ b/Dalamud.FindAnything/TextureCache.cs
@@ -18,6 +18,8 @@ namespace Dalamud.FindAnything
         public IReadOnlyDictionary<uint, IDalamudTextureWrap> ClassJobIcons { get; }
         public IReadOnlyDictionary<uint, IDalamudTextureWrap> MountIcons { get; }
         public IReadOnlyDictionary<uint, IDalamudTextureWrap> MinionIcons { get; }
+        public IReadOnlyDictionary<uint, IDalamudTextureWrap> FashionAccessoryIcons { get; }
+        public IReadOnlyDictionary<uint, IDalamudTextureWrap> CollectionIcons { get; }
 
         public Dictionary<uint, IDalamudTextureWrap> ExtraIcons { get; }
 
@@ -147,6 +149,28 @@ namespace Dalamud.FindAnything
             }
             MinionIcons = minionIcons;
 
+            var fashionAccessoryIcons = new Dictionary<uint, IDalamudTextureWrap>();
+            foreach (var ornament in data.GetExcelSheet<Ornament>()!)
+            {
+                var icon = GetIconTexture(ornament.Icon);
+                if (icon == null)
+                    continue;
+
+                fashionAccessoryIcons.Add(ornament.RowId, icon);
+            }
+            FashionAccessoryIcons = fashionAccessoryIcons;
+
+            var collectionIcons = new Dictionary<uint, IDalamudTextureWrap>();
+            foreach (var mcGuffin in data.GetExcelSheet<McGuffinUIData>()!)
+            {
+                var icon = GetIconTexture(mcGuffin.Icon);
+                if (icon == null)
+                    continue;
+
+                collectionIcons.Add(mcGuffin.RowId, icon);
+            }
+            CollectionIcons = collectionIcons;
+
             AetheryteIcon = GetIconTexture(066417)!;
             WikiIcon = GetIconTexture(066404)!;
             PluginInstallerIcon = GetIconTexture(066472)!;
@@ -224,6 +248,16 @@ namespace Dalamud.FindAnything
             }
 
             foreach (var icon in MinionIcons)
+            {
+                icon.Value.Dispose();
+            }
+
+            foreach (var icon in FashionAccessoryIcons)
+            {
+                icon.Value.Dispose();
+            }
+
+            foreach (var icon in CollectionIcons)
             {
                 icon.Value.Dispose();
             }


### PR DESCRIPTION
Adds support for searching Fashion Accessories and Collections (i.e. Mogpendium, Aether Compass, etc.).

Unfortunately using Collection items (`McGuffin`s internally) requires a signature, and I wasn't quite sure where to put it. In the end I copied the way the `Command` class works, renamed it to `Interop` and did it that way. Although I wonder if it makes sense to also move the `Command` logic into `Interop` since they are very similar at this point.

Decisions like the above, and decisions about about default ordering and so on were made arbitrarily, so feel free to let me know if you have any preferences there and I'll be happy to modify accordingly.