### PR TITLE
Handle special case of Gamepad Settings main command

### DIFF
--- a/Dalamud.FindAnything/SearchDatabase.cs
+++ b/Dalamud.FindAnything/SearchDatabase.cs
@@ -4,6 +4,7 @@ using Dalamud.Utility;
 using Lumina.Excel;
 using Lumina.Excel.GeneratedSheets;
 using Lumina.Text;
+using Lumina.Text.Payloads;
 
 namespace Dalamud.FindAnything
 {
@@ -69,6 +70,16 @@ namespace Dalamud.FindAnything
                 if (result != null)
                 {
                     var textVal = result.ToDalamudString().TextValue;
+
+                    // Handle special case of <if([gnum75>0],Controller,Gamepad)> Settings
+                    if (excelRow is MainCommand
+                        && result.Payloads is [{ PayloadType: PayloadType.If } ifPayload, { PayloadType: PayloadType.Text } textPayload]
+                        && ifPayload.Expressions[0].ToString() == "[gnum75>0]")
+                    {
+                        // Just use the second candidate (gnum75 == 0) since we're never on console
+                        textVal = (ifPayload.Expressions[2].ToString() ?? "Gamepad") + textPayload;
+                    }
+
                     data.Add(excelRow.RowId, new SearchEntry
                     {
                         Display = textVal,


### PR DESCRIPTION
Currently, the Gamepad Settings main command is displayed as ` Command`. This is because the command name includes a non-text `If` payload in Lumina, which switches between `Controller` on console platforms and `Gamepad` on PC. Since we're always on PC, this change handles the special case by always using the "else" part of that condition.

The solution is kind of ugly, but it seemed simpler to special case this one command rather than attempting to invoke `PronounModule` or similar to actually parse the expression.

There are a few other Lumina rows we use which also contain non-text payloads, but it looks like they are just italic on/off flags which are correctly stripped by `.ToDalamudString().TextValue` and don't need special handling.