### PR TITLE
Use simpler IsGameFocused check

### DIFF
--- a/Dalamud.FindAnything/Input.cs
+++ b/Dalamud.FindAnything/Input.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using Dalamud.Game.ClientState.Keys;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
 
 namespace Dalamud.FindAnything;
@@ -9,24 +9,8 @@ namespace Dalamud.FindAnything;
 // Most of this is stolen from QoLBar
 public unsafe class Input
 {
-    [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)] private static extern IntPtr GetForegroundWindow();
-    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)] private static extern int GetWindowThreadProcessId(IntPtr handle, out int processId);
-    private static bool IsGameFocused
-    {
-        get
-        {
-            var activatedHandle = GetForegroundWindow();
-            if (activatedHandle == IntPtr.Zero)
-                return false;
-
-            _ = GetWindowThreadProcessId(activatedHandle, out var activeProcId);
-
-            return activeProcId == Environment.ProcessId;
-        }
-    }
-
-    private static bool IsGameTextInputActive =>
-        Framework.Instance()->GetUiModule()->GetRaptureAtkModule()->AtkModule.IsTextInputActive();
+    private static bool IsGameFocused => !Framework.Instance()->WindowInactive;
+    private static bool IsGameTextInputActive => RaptureAtkModule.Instance()->AtkModule.IsTextInputActive();
 
     public static bool Disabled => IsGameTextInputActive || !IsGameFocused || ImGui.GetIO().WantCaptureKeyboard;
 


### PR DESCRIPTION
We can look up the game focus state with `Framework.Instance()->WindowInactive` rather than using a `winuser.h` call. Technically this can be delayed by 1 frame (since our tick runs before game logic) but in the case of Wotsit I don't think this should matter (it would only matter if the key or button which calls Wotsit was used in the same frame that the game loses focus).