### PR TITLE
Fix useMcGuffin sig

### DIFF
--- a/Dalamud.FindAnything/Interop.cs
+++ b/Dalamud.FindAnything/Interop.cs
@@ -15,7 +15,7 @@ public class Interop
 
     private delegate byte UseMcGuffinDelegate(IntPtr module, uint id);
 
-    [Signature("E8 ?? ?? ?? ?? EB 0C 48 8B 07")]
+    [Signature("48 89 5C 24 ?? 57 48 83 EC 40 80 3D ?? ?? ?? ?? ??")]
     private readonly UseMcGuffinDelegate? useMcGuffin = null!;
 
     public Interop()


### PR DESCRIPTION
This sig was hitting a different function in Dawntrail and causing crashes when a collection item was used. This fixes it.