### PR TITLE
fix: properly strip formatting from PlaceName

### DIFF
--- a/Dalamud.FindAnything/AetheryteManager.cs
+++ b/Dalamud.FindAnything/AetheryteManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Dalamud.Game;
 using Dalamud.Game.ClientState.Aetherytes;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using Lumina.Excel.Sheets;
 
@@ -110,7 +111,7 @@ namespace Dalamud.FindAnything {
             var sheet = FindAnythingPlugin.Data.GetExcelSheet<Aetheryte>(language)!;
             dict.Clear();
             foreach (var row in sheet) {
-                var name = row.PlaceName.ValueNullable?.Name.ToString();
+                var name = row.PlaceName.ValueNullable?.Name.ToDalamudString().TextValue;
                 if (string.IsNullOrEmpty(name))
                     continue;
                 name = FindAnythingPlugin.PluginInterface.Sanitizer.Sanitize(name);
@@ -122,7 +123,7 @@ namespace Dalamud.FindAnything {
             var sheet = FindAnythingPlugin.Data.GetExcelSheet<Aetheryte>(language)!;
             dict.Clear();
             foreach (var row in sheet) {
-                var name = row.Territory.ValueNullable?.PlaceName.ValueNullable?.Name.ToString();
+                var name = row.Territory.ValueNullable?.PlaceName.ValueNullable?.Name.ToDalamudString().TextValue;
                 if (string.IsNullOrEmpty(name))
                     continue;
                 if (row is not { IsAetheryte: true }) continue;


### PR DESCRIPTION
This makes sure to keep consistency when playing in German by removing "soft-hyphens" and other formatting from PlaceName strings by using Dalamud's `ToDalamudString().TextValue` instead of `ToString()`. 

Without Fix:
![grafik](https://github.com/user-attachments/assets/71da22b5-49e2-4e6b-9e59-9e01262e5010)
With Fix:
![grafik](https://github.com/user-attachments/assets/c205c327-810a-433a-8807-14cd8fffe6a7)
