### PR TITLE
Fix DutySearchResult and remove nonbreaking spaces from all search results

### DIFF
--- a/Dalamud.FindAnything/AetheryteManager.cs
+++ b/Dalamud.FindAnything/AetheryteManager.cs
@@ -110,7 +110,7 @@ namespace Dalamud.FindAnything {
             var sheet = FindAnythingPlugin.Data.GetExcelSheet<Aetheryte>(language)!;
             dict.Clear();
             foreach (var row in sheet) {
-                var name = row.PlaceName.ValueNullable?.Name.ToString();
+                var name = row.PlaceName.ValueNullable?.Name.ToText();
                 if (string.IsNullOrEmpty(name))
                     continue;
                 name = FindAnythingPlugin.PluginInterface.Sanitizer.Sanitize(name);
@@ -122,7 +122,7 @@ namespace Dalamud.FindAnything {
             var sheet = FindAnythingPlugin.Data.GetExcelSheet<Aetheryte>(language)!;
             dict.Clear();
             foreach (var row in sheet) {
-                var name = row.Territory.ValueNullable?.PlaceName.ValueNullable?.Name.ToString();
+                var name = row.Territory.ValueNullable?.PlaceName.ValueNullable?.Name.ToText();
                 if (string.IsNullOrEmpty(name))
                     continue;
                 if (row is not { IsAetheryte: true }) continue;

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1594,7 +1594,8 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedDutyKeys.Contains(cfc.Key))
                                             continue;
 
-                                        if (Data.GetExcelSheet<ContentFinderCondition>().GetRowOrDefault(cfc.Key) is not { } contentType)
+                                        if (Data.GetExcelSheet<ContentFinderCondition>().GetRowOrDefault(cfc.Key) is not
+                                            { ContentType.ValueNullable: { } contentType } row)
                                             continue;
 
                                         /*
@@ -1622,7 +1623,7 @@ namespace Dalamud.FindAnything
                                             cResults.Add(new DutySearchResult
                                             {
                                                 Score = score * weight,
-                                                CatName = contentType.Name.ExtractText(),
+                                                CatName = row.Name.ExtractText(),
                                                 DataKey = cfc.Key,
                                                 Name = cfc.Value.Display,
                                                 Icon = TexCache.GetIcon(contentType.Icon),

--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -35,6 +35,7 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Client.UI.Shell;
 using ImGuiNET;
 using Lumina.Excel.Sheets;
+using Lumina.Extensions;
 using NCalc;
 
 namespace Dalamud.FindAnything
@@ -1098,7 +1099,7 @@ namespace Dalamud.FindAnything
         private class MountResult : ISearchResult, IEquatable<MountResult>
         {
             public string CatName => "Mount";
-            public string Name => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Mount.Singular.ExtractText());
+            public string Name => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Mount.Singular.ToText());
             public ISharedImmediateTexture? Icon => TexCache.GetIcon(Mount.Icon);
             public int Score { get; set; }
             public bool CloseFinder => true;
@@ -1134,7 +1135,7 @@ namespace Dalamud.FindAnything
         private class MinionResult : ISearchResult, IEquatable<MinionResult>
         {
             public string CatName => "Minion";
-            public string Name => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Minion.Singular.ExtractText());
+            public string Name => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Minion.Singular.ToText());
             public ISharedImmediateTexture? Icon => TexCache.GetIcon(Minion.Icon);
             public int Score { get; set; }
             public bool CloseFinder => true;
@@ -1173,7 +1174,7 @@ namespace Dalamud.FindAnything
                 get
                 {
                     if (CraftType != null) {
-                        return $"Crafting Recipe ({CraftType?.Name.ExtractText()})";
+                        return $"Crafting Recipe ({CraftType?.Name.ToText()})";
                     }
 
                     return "Crafting Recipe";
@@ -1261,7 +1262,7 @@ namespace Dalamud.FindAnything
         private class FashionAccessoryResult : ISearchResult, IEquatable<FashionAccessoryResult>
         {
             public string CatName => "Fashion Accessory";
-            public string Name => Ornament.Singular.ExtractText();
+            public string Name => Ornament.Singular.ToText();
             public ISharedImmediateTexture? Icon => TexCache.GetIcon(Ornament.Icon);
             public int Score { get; set; }
             public bool CloseFinder => true;
@@ -1297,7 +1298,7 @@ namespace Dalamud.FindAnything
         private class CollectionResult : ISearchResult, IEquatable<CollectionResult>
         {
             public string CatName => "Collection";
-            public string Name => McGuffinUIData.Name.ExtractText();
+            public string Name => McGuffinUIData.Name.ToText();
             public ISharedImmediateTexture? Icon => TexCache.GetIcon(McGuffinUIData.Icon);
             public int Score { get; set; }
             public bool CloseFinder => true;
@@ -1623,7 +1624,7 @@ namespace Dalamud.FindAnything
                                             cResults.Add(new DutySearchResult
                                             {
                                                 Score = score * weight,
-                                                CatName = row.Name.ExtractText(),
+                                                CatName = row.Name.ToText(),
                                                 DataKey = cfc.Key,
                                                 Name = cfc.Value.Display,
                                                 Icon = TexCache.GetIcon(contentType.Icon),
@@ -1825,10 +1826,10 @@ namespace Dalamud.FindAnything
 
                                         var score = matcher.MatchesAny(
                                             text.Searchable,
-                                            slashCmd.Command.ExtractText(),
-                                            slashCmd.Alias.ExtractText(),
-                                            slashCmd.ShortCommand.ExtractText(),
-                                            slashCmd.ShortAlias.ExtractText()
+                                            slashCmd.Command.ToText(),
+                                            slashCmd.Alias.ToText(),
+                                            slashCmd.ShortCommand.ToText(),
+                                            slashCmd.ShortAlias.ToText()
                                         );
                                         if (score > 0)
                                         {
@@ -1836,7 +1837,7 @@ namespace Dalamud.FindAnything
                                             {
                                                 Score = score * weight,
                                                 Name = text.Display,
-                                                SlashCommand = slashCmd.Command.ExtractText(),
+                                                SlashCommand = slashCmd.Command.ToText(),
                                                 Icon = TexCache.GetIcon(emoteRow.Icon)
                                             });
 
@@ -1910,8 +1911,8 @@ namespace Dalamud.FindAnything
 
                                         var score = matcher.MatchesAny(
                                             gearset.Name.Downcase(normalizeKana),
-                                            cjRow.Name.ExtractText().Downcase(normalizeKana),
-                                            cjRow.Abbreviation.ExtractText().ToLowerInvariant(),
+                                            cjRow.Name.ToText().Downcase(normalizeKana),
+                                            cjRow.Abbreviation.ToText().ToLowerInvariant(),
                                             ClassJobRolesMap[gearset.ClassJob]
                                         );
                                         if (score > 0)
@@ -2000,7 +2001,7 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedMountKeys.Contains(mount.RowId))
                                             continue;
 
-                                        var score = matcher.Matches(mount.Singular.ExtractText().Downcase(normalizeKana));
+                                        var score = matcher.Matches(mount.Singular.ToText().Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new MountResult
@@ -2023,7 +2024,7 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedMinionKeys.Contains(minion.RowId))
                                             continue;
 
-                                        var score = matcher.Matches(minion.Singular.ExtractText().Downcase(normalizeKana));
+                                        var score = matcher.Matches(minion.Singular.ToText().Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new MinionResult
@@ -2076,7 +2077,7 @@ namespace Dalamud.FindAnything
                                         if (!GameStateCache.UnlockedFashionAccessoryKeys.Contains(ornament.RowId))
                                             continue;
 
-                                        var score = matcher.Matches(ornament.Singular.ExtractText().Downcase(normalizeKana));
+                                        var score = matcher.Matches(ornament.Singular.ToText().Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new FashionAccessoryResult
@@ -2100,7 +2101,7 @@ namespace Dalamud.FindAnything
                                             continue;
 
                                         var uiData = mcGuffin.UIData.Value!; // Already checked validity in UnlockedCollectionKeys
-                                        var score = matcher.Matches(uiData.Name.ExtractText().Downcase(normalizeKana));
+                                        var score = matcher.Matches(uiData.Name.ToText().Downcase(normalizeKana));
                                         if (score > 0)
                                         {
                                             cResults.Add(new CollectionResult
@@ -2237,7 +2238,7 @@ namespace Dalamud.FindAnything
 
                 case SearchMode.Wiki:
                 {
-                    var terriContent = Data.GetExcelSheet<ContentFinderCondition>()!
+                    var terriContent = Data.GetExcelSheet<ContentFinderCondition>()
                         .FirstOrNull(x => x.TerritoryType.RowId == ClientState.TerritoryType);
                     var score = matcher.Matches("here");
                     if (score > 0 && terriContent != null)
@@ -2245,7 +2246,7 @@ namespace Dalamud.FindAnything
                         cResults.Add(new WikiSearchResult
                         {
                             Score = int.MaxValue,
-                            Name = terriContent.Value.Name.ExtractText(),
+                            Name = terriContent.Value.Name.ToText(),
                             DataKey = terriContent.Value.RowId,
                             Icon = TexCache.WikiIcon,
                             CatName = "Current Duty",

--- a/Dalamud.FindAnything/LuminaExtensions.cs
+++ b/Dalamud.FindAnything/LuminaExtensions.cs
@@ -1,18 +1,71 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Lumina.Text.Payloads;
+using Lumina.Text.ReadOnly;
+using System;
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dalamud.FindAnything;
 
 public static class LuminaExtensions
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static T? FirstOrNull<T>(this IEnumerable<T> values, Func<T, bool> predicate) where T : struct
+    /// <summary>
+    /// Modified version of Lumina's ExtractText which renders a ReadOnlySeString in a way that's suited to display and
+    /// text matching, by avoiding unsearchable characters and characters that don't render correctly.
+    /// </summary>
+    /// <param name="str">The source ReadOnlySeString</param>
+    /// <returns>A plain string</returns>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    [SuppressMessage("ReSharper", "SwitchStatementMissingSomeEnumCasesNoDefault")] // Just skip them
+    public static string ToText(this ReadOnlySeString str)
     {
-        foreach (var val in values)
-            if (predicate(val))
-                return val;
+        var span = str.AsSpan();
+        var len = 0;
+        foreach (var v in span) {
+            switch (v.Type) {
+                case ReadOnlySePayloadType.Text:
+                    len += Encoding.UTF8.GetCharCount(v.Body);
+                    break;
+                case ReadOnlySePayloadType.Macro:
+                {
+                    // Skip rendering NonBreakingSpace and SoftHyphen entirely
+                    switch (v.MacroCode) {
+                        case MacroCode.NewLine:
+                        case MacroCode.Hyphen:
+                            len += 1;
+                            break;
+                    }
+                    break;
+                }
+            }
+        }
 
-        return null;
+        var buf = new char[len];
+        var bufspan = buf.AsSpan();
+        foreach (var v in span) {
+            switch (v.Type) {
+                case ReadOnlySePayloadType.Text:
+                    bufspan = bufspan[Encoding.UTF8.GetChars(v.Body, bufspan) ..];
+                    break;
+                case ReadOnlySePayloadType.Macro:
+                {
+                    switch (v.MacroCode) {
+                        case MacroCode.NewLine:
+                            bufspan[0] = ' ';
+                            bufspan = bufspan[1..];
+                            break;
+
+                        case MacroCode.Hyphen:
+                            bufspan[0] = '-';
+                            bufspan = bufspan[1..];
+                            break;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return new string(buf);
     }
 }

--- a/Dalamud.FindAnything/SearchDatabase.cs
+++ b/Dalamud.FindAnything/SearchDatabase.cs
@@ -68,13 +68,13 @@ namespace Dalamud.FindAnything
             {
                 if (rowToFind.Invoke(excelRow) is { } result)
                 {
-                    var textVal = result.ExtractText();
+                    var textVal = result.ToText();
                     if (textVal.IsNullOrEmpty())
                         continue;
 
                     try {
                         if (excelRow is MainCommand && textVal.StartsWith(" ")) {
-                            var macroText = result.ToString();
+                            var macroText = result.ToString(); // Using ToString on purpose to grab macro details below
                             if (macroText.StartsWith("<if([gnum75>0")) {
                                 textVal = macroText.Split(")")[0].Split(",")[2] + textVal;
                             }

--- a/Dalamud.FindAnything/StringExtensions.cs
+++ b/Dalamud.FindAnything/StringExtensions.cs
@@ -27,7 +27,7 @@ public static class StringExtensions
                         }
                     }
 
-                    return new ReadOnlySpan<char>(buffer).ToString();
+                    return new string(buffer);
                 }
             }
         }


### PR DESCRIPTION
I messed up one of the Lumina changes and was checking the duty ID/Icon rather than content type ID/Icon. This fixes it.