### PR TITLE
Strip job lock icon from wiki quest URLs

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -223,7 +223,7 @@ namespace Dalamud.FindAnything
                 var name = input.Replace(' ', '_');
                 name = name.Replace('–', '-');
 
-                if (name.StartsWith("_")) // "level sync" icon
+                if (name.StartsWith("_") || name.StartsWith("_")) // "level sync" or "job lock" icon
                     name = name.Substring(2);
 
                 switch (choice)


### PR DESCRIPTION
Strips the "job lock" icon from quest names when opening wiki entries, just like we already do for level sync icons.