### PR TITLE
Fix Notification.IconTexture

### DIFF
--- a/Dalamud.FindAnything/Game/GameWindow.cs
+++ b/Dalamud.FindAnything/Game/GameWindow.cs
@@ -273,7 +273,7 @@ public class GameWindow : Window
 
             FindAnythingPlugin.Notifications.AddNotification(new Notification
             {
-                IconTextureTask = this.noseTextures[NoseKind.Normal].RentAsync()!,
+                IconTexture = this.noseTextures[NoseKind.Normal],
                 Title = "Earned rested DN!",
                 Content = $"You earned {earnedRestedDn:N0} DN from resting for {numHoursSpent} hours.",
                 InitialDuration = TimeSpan.FromSeconds(10),


### PR DESCRIPTION
Jumped the gun on these fixes and did it before the `Notification` texture change. This fixes that. Sorry!