### PR TITLE
Use simpler action checks for mount, summon minion and teleport

### DIFF
--- a/Dalamud.FindAnything/FindAnythingPlugin.cs
+++ b/Dalamud.FindAnything/FindAnythingPlugin.cs
@@ -1684,7 +1684,7 @@ namespace Dalamud.FindAnything
                                 }
                                 break;
                             case Configuration.SearchSetting.Aetheryte:
-                                if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.Aetheryte) && CanTeleport())
+                                if (Configuration.ToSearchV3.HasFlag(Configuration.SearchSetting.Aetheryte) && !isInDuty && !isInCombat)
                                 {
                                     var marketBoardResults = new List<IAetheryteEntry>();
                                     var strikingDummyResults = new List<IAetheryteEntry>();


### PR DESCRIPTION
When checking availability of teleport, mounts and minions, rather then checking territory or duty state, check if the Teleport, Mount Roulette or Minion Roulette general actions are usable.

This should fix issues like mounts being unavailable in Occult Crescent.